### PR TITLE
Fix: Callback is not called on JS Thread

### DIFF
--- a/src/hooks/useCarouselController.tsx
+++ b/src/hooks/useCarouselController.tsx
@@ -105,7 +105,9 @@ export function useCarouselController(opts: IOpts): ICarouselController {
                 toValue,
                 { duration, easing: Easing.easeOutQuart },
                 (isFinished: boolean) => {
-                    callback?.();
+                    if (callback) {
+                        runOnJS(callback)();
+                    }
                     if (isFinished) {
                         runOnJS(onScrollEnd)();
                     }


### PR DESCRIPTION
Not calling the "optional" Callback on JS Thread breaks with Reanimated2 and crashes the host app when #ref.goToIndex(...)