### PR TITLE
Added tip for better UX when Carousel within scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,19 @@ import Carousel from 'react-native-reanimated-carousel';
 
     -   When rendering a large number of elements, you can use the 'windowSize' property to control how many items of the current element are rendered. The default is full rendering. After testing without this property, frames will drop when rendering 200 empty views. After setting this property, rendering 1000 empty views is still smooth. (The specific number depends on the phone model tested)
 
+-   User Experience
+
+    -   **[#143](https://github.com/dohooo/react-native-reanimated-carousel/issues/143) - Carousel suppresses ScrollView/FlastList scroll gesture handler:** When using a carousel with a layout oriented to only one direction (vertical/horizontal) and inside a ScrollView/FlatList, it is important for the user experience that the unused axis does not impede the scroll of the list. So that, for example, the x-axis is free we can change the offset of the gesture handler:
+
+        ```tsx
+        <Carousel
+          {...}
+          panGestureHandlerProps={{
+            activeOffsetX: [-10, 10],
+          }}
+        />
+        ```
+
 -   RTL
     -   Support to RTL mode with no more configuration needed. But in RTL mode, need to manually set the autoPlayReverse props for autoplay to control scrolling direction.
 -   EXPO


### PR DESCRIPTION
Added a tip in README with explanations and related issue to help users who want to free one of the axes when using Carousel inside a ScrollView/FlatList. For more details and use case, see https://github.com/dohooo/react-native-reanimated-carousel/issues/143

Sorry, my Chinese is not up to date, I ask someone to translate the README.