### PR TITLE
fix: "defaultIndex" wasn't define internal values (UI bridge and refs)

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -42,6 +42,7 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
             onScrollBegin,
             onProgressChange,
             customAnimation,
+            defaultIndex,
         } = props;
 
         const commonVariables = useCommonVariables(props);
@@ -69,6 +70,7 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
             disable: !data.length,
             withAnimation,
             originalLength: data.length,
+            defaultIndex,
             onScrollEnd: () => runOnJS(_onScrollEnd)(),
             onScrollBegin: () => !!onScrollBegin && runOnJS(onScrollBegin)(),
             onChange: (i) => !!onSnapToItem && runOnJS(onSnapToItem)(i),

--- a/src/hooks/useCarouselController.tsx
+++ b/src/hooks/useCarouselController.tsx
@@ -18,6 +18,7 @@ interface IOpts {
     duration?: number;
     originalLength: number;
     length: number;
+    defaultIndex?: number;
     onScrollBegin?: () => void;
     onScrollEnd?: () => void;
     // the length before fill data
@@ -48,12 +49,13 @@ export function useCarouselController(options: IOpts): ICarouselController {
         length,
         onChange,
         duration,
+        defaultIndex = 0,
     } = options;
 
-    const index = useSharedValue<number>(0);
+    const index = useSharedValue<number>(defaultIndex);
     // The Index displayed to the user
-    const sharedIndex = React.useRef<number>(0);
-    const sharedPreIndex = React.useRef<number>(0);
+    const sharedIndex = React.useRef<number>(defaultIndex);
+    const sharedPreIndex = React.useRef<number>(defaultIndex);
 
     const currentFixedPage = React.useCallback(() => {
         if (loop) {


### PR DESCRIPTION
**Problems:**
1. If I set the X value to defaultIndex, when "onScrollEnd" is invoked the "previous" parameter is not the X value but 0.
2. #156

**Correction:**
I noticed that defaultIndex was only used to define the carousel view, it wasn't updating the UI bridge or the module's internal references.

All I did was make the default value of bridge and refs defaultIndex.