### PR TITLE
fix: update typescript index in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "2.3.8",
     "description": "Simple carousel component.fully implemented using Reanimated 2.Infinitely scrolling, very smooth.",
     "main": "lib/commonjs/index",
-    "types": "lib/typescript/index.d.ts",
+    "types": "lib/typescript/src/index.d.ts",
     "source": "src/index",
     "files": [
         "src",


### PR DESCRIPTION
The path for typescript definitions is incorrect in package.json
