### PR TITLE
feat: add handlerOffsetX to ref

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -144,8 +144,9 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
                 prev,
                 getCurrentIndex,
                 scrollTo,
+                scrollOffset: handlerOffsetX,
             }),
-            [getCurrentIndex, next, prev, scrollTo]
+            [getCurrentIndex, next, prev, scrollTo, handlerOffsetX]
         );
 
         const visibleRanges = useVisibleRanges({

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import type { StyleProp, ViewStyle } from 'react-native';
 import type { PanGestureHandlerProps } from 'react-native-gesture-handler';
 import type {
     AnimatedStyleProp,
+    SharedValue,
     WithSpringConfig,
     WithTimingConfig,
 } from 'react-native-reanimated';
@@ -204,6 +205,11 @@ export interface ICarouselInstance {
      * scrollTo(-2) is equivalent to prev(2), scrollTo(2) is equivalent to next(2)
      */
     scrollTo: (opts?: TCarouselActionOptions) => void;
+    /**
+     * Animated value of current scroll / offset-x to extend carousel animation functionality
+     * It's useful when tight animation of custom components to carousel swiping
+     */
+    scrollOffset: SharedValue<number>;
 }
 
 export interface CarouselRenderItemInfo<ItemT> {


### PR DESCRIPTION
I need `handlerOffsetX` to be in `ref` so I can use it to sync external animation like changing background while swiping. 
It's basically to simulate `onScroll` event and to update animated value with `offsetX` . 
I tried to use `onProgressChange` but it's triggered too late when swiping too fast and the animation doesn't feel very smooth. 