### PR TITLE
Make MaxPage Configurable

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -45,6 +45,7 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
       onProgressChange,
       customAnimation,
       defaultIndex,
+      maxScrollablePage,
     } = props;
 
     const commonVariables = useCommonVariables(props);

--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -218,6 +218,7 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
           onScrollEnd={scrollViewGestureOnScrollEnd}
           onTouchBegin={scrollViewGestureOnTouchBegin}
           onTouchEnd={scrollViewGestureOnTouchEnd}
+          maxScrollablePage={maxScrollablePage}
         >
           {data.map(renderLayout)}
         </ScrollViewGesture>

--- a/src/ScrollViewGesture.tsx
+++ b/src/ScrollViewGesture.tsx
@@ -35,6 +35,7 @@ interface Props {
   onTouchBegin?: () => void
   onTouchEnd?: () => void
   translation: Animated.SharedValue<number>
+  maxScrollablePage?: number;
 }
 
 const IScrollViewGesture: React.FC<Props> = (props) => {
@@ -49,6 +50,7 @@ const IScrollViewGesture: React.FC<Props> = (props) => {
       scrollAnimationDuration,
       withAnimation,
       enabled,
+      maxScrollablePage,
     },
   } = React.useContext(CTX);
 
@@ -63,7 +65,7 @@ const IScrollViewGesture: React.FC<Props> = (props) => {
     onTouchEnd,
   } = props;
 
-  const maxPage = data.length;
+  const maxPage = maxScrollablePage || data.length;
   const isHorizontal = useDerivedValue(() => !vertical, [vertical]);
   const touching = useSharedValue(false);
   const scrollEndTranslation = useSharedValue(0);

--- a/src/ScrollViewGesture.tsx
+++ b/src/ScrollViewGesture.tsx
@@ -35,7 +35,7 @@ interface Props {
   onTouchBegin?: () => void
   onTouchEnd?: () => void
   translation: Animated.SharedValue<number>
-  maxScrollablePage?: number;
+  maxScrollablePage?: number
 }
 
 const IScrollViewGesture: React.FC<Props> = (props) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,6 +188,10 @@ export type TCarouselProps<T = any> = {
     offsetProgress: number,
     absoluteProgress: number
   ) => void
+  /**
+     * The last page we're allowed to scroll to.
+     */
+   maxScrollablePage: number
 } & (TParallaxModeProps | TStackModeProps);
 
 export interface ICarouselInstance {

--- a/src/types.ts
+++ b/src/types.ts
@@ -191,7 +191,7 @@ export type TCarouselProps<T = any> = {
   /**
      * The last page we're allowed to scroll to.
      */
-   maxScrollablePage: number
+  maxScrollablePage?: number
 } & (TParallaxModeProps | TStackModeProps);
 
 export interface ICarouselInstance {


### PR DESCRIPTION
This PR adds support to configuring maxPage on the carousel. 

This supports the use case where we have multiple items on the page, and have `loop={false}`.

Before, we would allow the carousel to "overscroll", however by setting the maxPage to `pages.length - visiblePages` we're able to stop scrolling once the last item is available.

**Before:**
![156445400-0c2a7f6c-7da2-40a9-9872-2669134bf535-1](https://user-images.githubusercontent.com/15078788/199108595-6529d07f-d7e5-45ae-9aa1-aac1fb079e11.gif)


**After:**
![156445400-0c2a7f6c-7da2-40a9-9872-2669134bf535](https://user-images.githubusercontent.com/15078788/199108506-b5f9b4cc-ceec-4131-989e-cfcfe0dfcb4b.gif)