### PR TITLE
feat: support header on carousel

### DIFF
--- a/exampleExpo/src/Home.tsx
+++ b/exampleExpo/src/Home.tsx
@@ -21,6 +21,7 @@ import Cube3D from "./cube-3d";
 import Curve from "./curve";
 import Flow from "./flow";
 import Fold from "./fold";
+import HeaderCarouselComponent from "./header-carousel";
 import LeftAlignComponent from "./left-align";
 import MarqueeComponent from "./marquee";
 import MultipleComponent from "./multiple";
@@ -61,6 +62,10 @@ export const LayoutsPage = [
   {
     name: "LeftAlign",
     page: LeftAlignComponent,
+  },
+  {
+    name: "HeaderCarousel",
+    page: HeaderCarouselComponent,
   },
 ];
 

--- a/exampleExpo/src/header-carousel/index.tsx
+++ b/exampleExpo/src/header-carousel/index.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { View } from "react-native";
+import type { ICarouselInstance } from "react-native-reanimated-carousel";
+import Carousel from "react-native-reanimated-carousel";
+
+import { SBItem } from "../components/SBItem";
+import { window } from "../constants";
+
+const PAGE_WIDTH = window.width;
+
+function Index() {
+  const [data] = React.useState([...new Array(4).keys()]);
+  const ref = React.useRef<ICarouselInstance>(null);
+  return (
+    <View style={{ flex: 1 }}>
+      <Carousel
+        width={PAGE_WIDTH}
+        height={PAGE_WIDTH / 2}
+        loop
+        ref={ref}
+        style={{ width: "100%" }}
+        data={data}
+        renderItem={({ index }) => <SBItem key={index} index={index} />}
+        headerHeight={200}
+        HeaderComponent={() => <View style={{ height: 200, backgroundColor: "green", width: "100%" }}></View>}
+      />
+    </View>
+  );
+}
+
+export default Index;

--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -51,8 +51,9 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
       onProgressChange,
       customAnimation,
       defaultIndex,
+      HeaderComponent,
+      headerHeight = 0,
     } = props;
-
     const commonVariables = useCommonVariables(props);
     const { size, handlerOffset } = commonVariables;
 
@@ -90,7 +91,7 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
     });
 
     const { next, prev, scrollTo, getSharedIndex, getCurrentIndex }
-            = carouselController;
+      = carouselController;
 
     const { start: startAutoPlay, pause: pauseAutoPlay } = useAutoPlay({
       autoPlay,
@@ -201,7 +202,7 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
     );
 
     return (
-      <CTX.Provider value={{ props, common: commonVariables }}>
+      <CTX.Provider value={{ props, common: commonVariables, headerHeight }}>
         <ScrollViewGesture
           key={mode}
           size={size}
@@ -210,7 +211,7 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
             styles.container,
             {
               width: width || "100%",
-              height: height || "100%",
+              height: (height + headerHeight) || "100%",
             },
             style,
             vertical
@@ -223,6 +224,10 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
           onTouchBegin={scrollViewGestureOnTouchBegin}
           onTouchEnd={scrollViewGestureOnTouchEnd}
         >
+
+          {HeaderComponent && !vertical && (
+            React.isValidElement(HeaderComponent) ? (HeaderComponent) : <HeaderComponent />
+          )}
           {data.map(renderLayout)}
         </ScrollViewGesture>
       </CTX.Provider>

--- a/src/layouts/BaseLayout.tsx
+++ b/src/layouts/BaseLayout.tsx
@@ -30,7 +30,7 @@ export const BaseLayout: React.FC<{
 }> = (props) => {
   const mounted = useCheckMounted();
   const { handlerOffset, index, children, visibleRanges, animationStyle }
-        = props;
+    = props;
 
   const context = React.useContext(CTX);
   const {
@@ -80,10 +80,10 @@ export const BaseLayout: React.FC<{
   const updateView = React.useCallback(
     (negativeRange: number[], positiveRange: number[]) => {
       mounted.current
-                && setShouldUpdate(
-                  (index >= negativeRange[0] && index <= negativeRange[1])
-                        || (index >= positiveRange[0] && index <= positiveRange[1]),
-                );
+        && setShouldUpdate(
+          (index >= negativeRange[0] && index <= negativeRange[1])
+          || (index >= positiveRange[0] && index <= positiveRange[1]),
+        );
     },
     [index, mounted],
   );
@@ -106,6 +106,7 @@ export const BaseLayout: React.FC<{
           width: width || "100%",
           height: height || "100%",
           position: "absolute",
+          top: context.headerHeight ?? 0,
         },
         animatedStyle,
       ]}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,6 +8,7 @@ export interface IContext {
     size: number
     validLength: number
   }
+  headerHeight: number
 }
 
 export const CTX = React.createContext<IContext>({} as IContext);

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,9 +163,12 @@ export type TCarouselProps<T = any> = {
      * Must use `worklet`, Details: https://docs.swmansion.com/react-native-reanimated/docs/2.2.0/worklets/
      */
   customAnimation?: (value: number) => AnimatedStyleProp<ViewStyle>
+  /**
+     * Define the height of the header on carousel.
+     */
   headerHeight?: number
   /**
-     * Render carousel header.
+     * Render header on carousel, only support horizontal mode.
      */
   HeaderComponent?:
   | React.ComponentType<any>

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,6 +163,15 @@ export type TCarouselProps<T = any> = {
      * Must use `worklet`, Details: https://docs.swmansion.com/react-native-reanimated/docs/2.2.0/worklets/
      */
   customAnimation?: (value: number) => AnimatedStyleProp<ViewStyle>
+  headerHeight?: number
+  /**
+     * Render carousel header.
+     */
+  HeaderComponent?:
+  | React.ComponentType<any>
+  | React.ReactElement
+  | null
+  | undefined
   /**
      * Render carousel item.
      */


### PR DESCRIPTION
# Why 

I want to trigger the `Carousel` component gestures when swiping without the slider area. 

# How 
Add the `HeaderComponent` to the inner  of `ScrollViewGesture` to support this feature, it's just like `FlatList`'s [ListHeaderComponent](https://reactnative.dev/docs/flatlist#listheadercomponent) 

# Test 



https://user-images.githubusercontent.com/37520667/207703645-480b7aa5-4a8b-42aa-b11c-55c329a8f395.mp4


