### PR TITLE
Parallax Horizontal Center Align

### DIFF
--- a/exampleExpo/src/pages/parallax/index.tsx
+++ b/exampleExpo/src/pages/parallax/index.tsx
@@ -31,7 +31,7 @@ function Index() {
   const baseOptions = isVertical
     ? ({
       vertical: true,
-      width: PAGE_WIDTH,
+      width: PAGE_WIDTH * 0.86,
       height: PAGE_WIDTH * 0.6,
     } as const)
     : ({
@@ -48,6 +48,9 @@ function Index() {
     >
       <Carousel
         {...baseOptions}
+        style={{
+           width: PAGE_WIDTH * 0.86,
+        }}
         loop
         pagingEnabled={pagingEnabled}
         snapEnabled={snapEnabled}


### PR DESCRIPTION
I was facing issues in smaller devices. Some part of carousel remained hidden. By adding the width in style prop fixed the issue. And multiplying it with 0.86 gave the best result. 