### PR TITLE
Metro config blacklist fix

### DIFF
--- a/exampleBare/metro.config.js
+++ b/exampleBare/metro.config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const blacklist = require('metro-config/src/defaults/blacklist');
+const blacklist = require('metro-config/src/defaults/exclusionList');
 const escape = require('escape-string-regexp');
 const pak = require('../package.json');
 


### PR DESCRIPTION
There is a metro related error in the blacklist module, the name of the dir was changed and an error was found running the base `yarn` command, This is an update to this problem. 