### PR TITLE
Inertial scroll for pagingEnabled=true case

### DIFF
--- a/src/ScrollViewGesture.tsx
+++ b/src/ScrollViewGesture.tsx
@@ -134,21 +134,29 @@ const IScrollViewGesture: React.FC<Props> = (props) => {
         const offset = -(scrollEndTranslation.value >= 0 ? 1 : -1); // 1 or -1
         const computed = offset < 0 ? Math.ceil : Math.floor;
         const page = computed(-translation.value / size);
-
-        if (infinite) {
-          const finalPage = page + offset;
+        if (snapEnabled) {
+          const maxFinalPage = -Math.round((origin + velocity * 0.4) / size);
+          let adjacentPage = page + offset;
+          if (!infinite)
+            adjacentPage = Math.min(maxPage - 1, Math.max(0, adjacentPage));
+          const computeFinalPage = offset < 0 ? Math.max : Math.min;
+          // Final page is either the current page or the adjacent page
+          const finalPage = computeFinalPage(adjacentPage, maxFinalPage);
           finalTranslation = withSpring(withProcessTranslation(-finalPage * size), onFinished);
         }
         else {
-          const finalPage = Math.min(maxPage - 1, Math.max(0, page + offset));
+          let finalPage = page + offset;
+          if (!infinite)
+            finalPage = Math.min(maxPage - 1, Math.max(0, page + offset));
           finalTranslation = withSpring(withProcessTranslation(-finalPage * size), onFinished);
         }
       }
-
-      if (!pagingEnabled && snapEnabled) {
-        // scroll to the nearest item
-        const nextPage = Math.round((origin + velocity * 0.4) / size) * size;
-        finalTranslation = withSpring(withProcessTranslation(nextPage), onFinished);
+      else {
+        if (snapEnabled) {
+          // scroll to the nearest item
+          const nextPage = Math.round((origin + velocity * 0.4) / size) * size;
+          finalTranslation = withSpring(withProcessTranslation(nextPage), onFinished);
+        }
       }
 
       translation.value = finalTranslation;


### PR DESCRIPTION
### Issue:
When paging is enabled, the user will be able to scroll to a new page by just scrolling a little. But users would prefer an inertial scroll situation where the page changes only if the user swipes fast or the swipe distance is considerable.
To illustrate the issue further,
1. assume the current page is page 1
2. scroll the carousel to the left a little so that page 2 is partially visible
3. without lifting your finger from the screen, scroll the carousel to the right all the way until only page 2 is minimally visible
4. now, ideally we want page 1 to be shown since we swiped right again. But the carousel abruptly auto scrolls to page 2

https://user-images.githubusercontent.com/40817254/225714743-52f85b00-2922-426c-bd04-21d332f42666.mov

### Fix:
Use inertial scroll. Inertial scroll is already implemented for when pagingEnabled=false.
Based on the distance and velocity of swipe, we determine if the final page should be an adjacent page or return back to the current page

https://user-images.githubusercontent.com/40817254/225715728-ccdce8ed-b719-4017-9ec0-ac4d057095e8.mov


