### PR TITLE
fix: off-by-one error in visible ranges calculation

### DIFF
--- a/src/hooks/useVisibleRanges.tsx
+++ b/src/hooks/useVisibleRanges.tsx
@@ -39,8 +39,15 @@ export function useVisibleRanges(options: {
       positiveRange[0] = 0;
     }
     if (positiveRange[0] > positiveRange[1]) {
-      negativeRange[1] = total - 1;
-      positiveRange[0] = 0;
+      if (positiveRange[1] == 0) {
+        negativeRange[1] = total - 1;
+        positiveRange[0] = total - 1;
+        positiveRange[1] = total - 1;
+      } else if (positiveRange[1] == 1) {
+        negativeRange[1] = positiveRange[0]
+        positiveRange[0] = 0;
+        positiveRange[1] = 1;
+      }
     }
     return { negativeRange, positiveRange };
   }, [total, windowSize, translation]);

--- a/src/layouts/BaseLayout.tsx
+++ b/src/layouts/BaseLayout.tsx
@@ -82,7 +82,7 @@ export const BaseLayout: React.FC<{
       mounted.current
                 && setShouldUpdate(
                   (index >= negativeRange[0] && index <= negativeRange[1])
-                        || (index >= positiveRange[0] && index <= positiveRange[1]),
+                        || (index >= positiveRange[0] && index < positiveRange[1]),
                 );
     },
     [index, mounted],

--- a/src/layouts/ParallaxLayout.tsx
+++ b/src/layouts/ParallaxLayout.tsx
@@ -107,7 +107,7 @@ export const ParallaxLayout: React.FC<PropsWithChildren<IComputedDirectionTypes<
     (negativeRange: number[], positiveRange: number[]) => {
       setShouldUpdate(
         (index >= negativeRange[0] && index <= negativeRange[1])
-                    || (index >= positiveRange[0] && index <= positiveRange[1]),
+                    || (index >= positiveRange[0] && index < positiveRange[1]),
       );
     },
     [index],


### PR DESCRIPTION
Currently, there's an issue with the useVisibleRanges calculation.

For example, when a `windowSize` of 3 is specified, the visible range specified by `{ negativeRange, positiveRange }` when scrolled to the end of the carousel sets the shouldUpdate state variable for 4 items instead of 3.