### PR TITLE
fix: reduce the amount of work done when rendering data

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
-import React from "react";
+import React, { Fragment } from "react";
 import { StyleSheet } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { runOnJS, useDerivedValue } from "react-native-reanimated";
@@ -13,6 +12,7 @@ import { useOnProgressChange } from "./hooks/useOnProgressChange";
 import { usePropsErrorBoundary } from "./hooks/usePropsErrorBoundary";
 import { useVisibleRanges } from "./hooks/useVisibleRanges";
 import { BaseLayout } from "./layouts/BaseLayout";
+import { LazyView } from "./LazyView";
 import { ScrollViewGesture } from "./ScrollViewGesture";
 import { CTX } from "./store";
 import type { ICarouselInstance, TCarouselProps } from "./types";
@@ -171,9 +171,10 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
           autoFillData,
         });
 
-        return (
+        const isLazy = !!windowSize;
+
+        const content = (
           <BaseLayout
-            key={i}
             index={i}
             handlerOffset={offsetX}
             visibleRanges={visibleRanges}
@@ -188,6 +189,8 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
             }
           </BaseLayout>
         );
+
+        return isLazy ? <LazyView key={i} index={i} visibleRanges={visibleRanges}>{content}</LazyView> : <Fragment key={i}>{content}</Fragment>;
       },
       [
         loop,
@@ -198,6 +201,7 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
         renderItem,
         layoutConfig,
         customAnimation,
+        windowSize,
       ],
     );
 

--- a/src/LazyView.tsx
+++ b/src/LazyView.tsx
@@ -1,15 +1,32 @@
-import type { PropsWithChildren } from "react";
-import React from "react";
+import React, { type PropsWithChildren, useState } from "react";
+import { runOnJS, useAnimatedReaction } from "react-native-reanimated";
+
+import type { IVisibleRanges } from "./hooks/useVisibleRanges";
 
 interface Props {
-  shouldUpdate: boolean
+  index: number
+  visibleRanges: IVisibleRanges
 }
 
 export const LazyView: React.FC<PropsWithChildren<Props>> = (props) => {
-  const { shouldUpdate, children } = props;
+  const { index, visibleRanges, children } = props;
 
-  if (!shouldUpdate)
-    return <></>;
+  const [shouldRender, setShouldRender] = useState<boolean>(false);
+
+  useAnimatedReaction(
+    () => {
+      const { negativeRange, positiveRange } = visibleRanges.value;
+      return (index >= negativeRange[0] && index <= negativeRange[1]) || (index >= positiveRange[0] && index <= positiveRange[1]);
+    },
+    (currentValue, previousValue) => {
+      if (currentValue !== previousValue)
+        runOnJS(setShouldRender)(currentValue);
+    },
+    [index, visibleRanges],
+  );
+
+  if (!shouldRender)
+    return null;
 
   return <>{children}</>;
 };

--- a/src/layouts/BaseLayout.tsx
+++ b/src/layouts/BaseLayout.tsx
@@ -2,19 +2,15 @@ import React from "react";
 import type { ViewStyle } from "react-native";
 import type { AnimatedStyleProp } from "react-native-reanimated";
 import Animated, {
-  runOnJS,
-  useAnimatedReaction,
   useAnimatedStyle,
   useDerivedValue,
 } from "react-native-reanimated";
 
 import type { ILayoutConfig } from "./stack";
 
-import { useCheckMounted } from "../hooks/useCheckMounted";
 import type { IOpts } from "../hooks/useOffsetX";
 import { useOffsetX } from "../hooks/useOffsetX";
 import type { IVisibleRanges } from "../hooks/useVisibleRanges";
-import { LazyView } from "../LazyView";
 import { CTX } from "../store";
 
 export type TAnimationStyle = (value: number) => AnimatedStyleProp<ViewStyle>;
@@ -28,9 +24,8 @@ export const BaseLayout: React.FC<{
     animationValue: Animated.SharedValue<number>
   }) => React.ReactElement
 }> = (props) => {
-  const mounted = useCheckMounted();
   const { handlerOffset, index, children, visibleRanges, animationStyle }
-  = props;
+        = props;
 
   const context = React.useContext(CTX);
   const {
@@ -46,7 +41,6 @@ export const BaseLayout: React.FC<{
     },
   } = context;
   const size = vertical ? height : width;
-  const [shouldUpdate, setShouldUpdate] = React.useState(false);
   let offsetXConfig: IOpts = {
     handlerOffset,
     index,
@@ -77,28 +71,6 @@ export const BaseLayout: React.FC<{
     [animationStyle],
   );
 
-  const updateView = React.useCallback(
-    (negativeRange: number[], positiveRange: number[]) => {
-      mounted.current
-                && setShouldUpdate(
-                  (index >= negativeRange[0] && index <= negativeRange[1])
-                        || (index >= positiveRange[0] && index <= positiveRange[1]),
-                );
-    },
-    [index, mounted],
-  );
-
-  useAnimatedReaction(
-    () => visibleRanges.value,
-    () => {
-      runOnJS(updateView)(
-        visibleRanges.value.negativeRange,
-        visibleRanges.value.positiveRange,
-      );
-    },
-    [visibleRanges.value],
-  );
-
   return (
     <Animated.View
       style={[
@@ -109,16 +81,9 @@ export const BaseLayout: React.FC<{
         },
         animatedStyle,
       ]}
-      /**
-       * We use this testID to know when the carousel item is ready to be tested in test.
-       * e.g.
-       *  The testID of first item will be changed to __CAROUSEL_ITEM_0_READY__ from __CAROUSEL_ITEM_0_NOT_READY__ when the item is ready.
-       * */
-      testID={`__CAROUSEL_ITEM_${index}_${shouldUpdate ? "READY" : "NOT_READY"}__`}
+      testID={`__CAROUSEL_ITEM_${index}`}
     >
-      <LazyView shouldUpdate={shouldUpdate}>
-        {children({ animationValue })}
-      </LazyView>
+      {children({ animationValue })}
     </Animated.View>
   );
 };

--- a/src/layouts/ParallaxLayout.tsx
+++ b/src/layouts/ParallaxLayout.tsx
@@ -3,8 +3,6 @@ import React from "react";
 import Animated, {
   Extrapolate,
   interpolate,
-  runOnJS,
-  useAnimatedReaction,
   useAnimatedStyle,
 } from "react-native-reanimated";
 
@@ -12,7 +10,6 @@ import type { ILayoutConfig } from "./parallax";
 
 import { useOffsetX } from "../hooks/useOffsetX";
 import type { IVisibleRanges } from "../hooks/useVisibleRanges";
-import { LazyView } from "../LazyView";
 import type { IComputedDirectionTypes } from "../types";
 
 export const ParallaxLayout: React.FC<PropsWithChildren<IComputedDirectionTypes<
@@ -38,8 +35,6 @@ export const ParallaxLayout: React.FC<PropsWithChildren<IComputedDirectionTypes<
     visibleRanges,
     vertical,
   } = props;
-
-  const [shouldUpdate, setShouldUpdate] = React.useState(false);
 
   const size = props.vertical ? props.height : props.width;
 
@@ -103,27 +98,6 @@ export const ParallaxLayout: React.FC<PropsWithChildren<IComputedDirectionTypes<
     };
   }, [loop, vertical, parallaxScrollingOffset]);
 
-  const updateView = React.useCallback(
-    (negativeRange: number[], positiveRange: number[]) => {
-      setShouldUpdate(
-        (index >= negativeRange[0] && index <= negativeRange[1])
-                    || (index >= positiveRange[0] && index <= positiveRange[1]),
-      );
-    },
-    [index],
-  );
-
-  useAnimatedReaction(
-    () => visibleRanges.value,
-    () => {
-      runOnJS(updateView)(
-        visibleRanges.value.negativeRange,
-        visibleRanges.value.positiveRange,
-      );
-    },
-    [visibleRanges.value],
-  );
-
   return (
     <Animated.View
       style={[
@@ -135,7 +109,7 @@ export const ParallaxLayout: React.FC<PropsWithChildren<IComputedDirectionTypes<
         offsetXStyle,
       ]}
     >
-      <LazyView shouldUpdate={shouldUpdate}>{children}</LazyView>
+      {children}
     </Animated.View>
   );
 };


### PR DESCRIPTION
The logic to conditionally render an item in the carousel was far, far too deep in the component hierarchy, making the windowSize config unusable. This PR lifts the logic up to significantly reduce the amount of work that needs to be done.

This should fix (or improve) #352, #362, and #258.

Some more work needs to be done on this. Mainly, the tests pass even though the testId in BaseLayout changed and they should fail as a result... Also, as far as I can tell the ParallaxLayout component is never used. If that's the case, the file should be removed.

This works for all of the use cases I have, but I don't have the time right now to dig into the unit tests right now and fully test the change, so if someone else could take a look it would be extremely helpful.