### PR TITLE
docs: fix scrollables link on usage page

### DIFF
--- a/example/website/pages/usage.mdx
+++ b/example/website/pages/usage.mdx
@@ -23,7 +23,7 @@ slug: /usage
 # Usage
 ---
 
-Here is a simple usage of the **React Native Reanimated Carousel**. For more scrollable usage please read [Scrollables](./scrollables).
+Here is a simple usage of the **React Native Reanimated Carousel**. For more scrollable usage please read [Scrollables](./faq#used-in-scrollviewflatlist).
 
 ```tsx
 import * as React from 'react';


### PR DESCRIPTION
I haven't tested this, just changed the link in github code editor.

Fixes #512 