### PR TITLE
feat: added onSnapToItem trigger for didMount and update index changing logic

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -153,6 +153,11 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
       [getCurrentIndex, next, prev, scrollTo],
     );
 
+    React.useEffect(() => {
+      // add onSnapToItem call when component is first mounted
+      onSnapToItem?.(defaultIndex || 0);
+    }, []);
+
     const visibleRanges = useVisibleRanges({
       total: dataLength,
       viewSize: size,

--- a/src/hooks/useOnProgressChange.ts
+++ b/src/hooks/useOnProgressChange.ts
@@ -42,6 +42,9 @@ export function useOnProgressChange(
       if (value > 0)
         absoluteProgress = rawDataLength - absoluteProgress;
 
+      if (absoluteProgress > (rawDataLength - 0.5)) // threshold set as half of the size
+        absoluteProgress = 0;
+
       if (onProgressChange)
         runOnJS(onProgressChange)(value, absoluteProgress);
     },


### PR DESCRIPTION
Changes made is to fix below issue:

1. No `onSnapToItem` trigger for initially mounted carousel item
2. For when `loop` is `true`, the index changes when scrolling beyond 1 loop and back to `index=0`, the `index` is first changed to `rawDataLength` before resetting to `0`, which will cause slight delay when updating pagination dots.