### PR TITLE
fix: `onGestureEnd` -> `endWithSpring` uses outdated data via `useSharedValue`

### DIFF
--- a/src/components/ScrollViewGesture.tsx
+++ b/src/components/ScrollViewGesture.tsx
@@ -116,15 +116,18 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
   );
 
   const endWithSpring = React.useCallback(
-    (onFinished?: () => void) => {
+    (scrollEndTranslationValue: number,
+      scrollEndVelocityValue: number,
+      onFinished?: () => void,
+    ) => {
       "worklet";
       const origin = translation.value;
-      const velocity = scrollEndVelocity.value;
+      const velocity = scrollEndVelocityValue;
       // Default to scroll in the direction of the slide (with deceleration)
       let finalTranslation: number = withDecay({ velocity, deceleration: 0.999 });
 
       // If the distance of the swipe exceeds the max scroll distance, keep the view at the current position
-      if (maxScrollDistancePerSwipeIsSet && Math.abs(scrollEndTranslation.value) > maxScrollDistancePerSwipe) {
+      if (maxScrollDistancePerSwipeIsSet && Math.abs(scrollEndTranslationValue) > maxScrollDistancePerSwipe) {
         finalTranslation = origin;
       }
       else {
@@ -137,9 +140,9 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
         * */
         if (pagingEnabled) {
           // distance with direction
-          const offset = -(scrollEndTranslation.value >= 0 ? 1 : -1); // 1 or -1
+          const offset = -(scrollEndTranslationValue >= 0 ? 1 : -1); // 1 or -1
           const computed = offset < 0 ? Math.ceil : Math.floor;
-          const page = computed(-translation.value / size);
+          const page = computed(-origin / size);
 
           if (loop) {
             const finalPage = page + offset;
@@ -178,9 +181,7 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
       snapEnabled,
       translation,
       pagingEnabled,
-      scrollEndVelocity.value,
       maxScrollDistancePerSwipe,
-      scrollEndTranslation.value,
       maxScrollDistancePerSwipeIsSet,
     ],
   );
@@ -335,9 +336,10 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
     "worklet";
 
     const { velocityX, velocityY, translationX, translationY } = e;
-    scrollEndVelocity.value = isHorizontal.value
+    const scrollEndVelocityValue = isHorizontal.value
       ? velocityX
       : velocityY;
+    scrollEndVelocity.value = scrollEndVelocityValue; // may update async: see https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue#remarks
 
     let panTranslation = isHorizontal.value
       ? translationX
@@ -349,9 +351,9 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
     else if (fixedDirection === "positive")
       panTranslation = +Math.abs(panTranslation);
 
-    scrollEndTranslation.value = panTranslation;
+    scrollEndTranslation.value = panTranslation; // may update async: see https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue#remarks
 
-    const totalTranslation = scrollEndVelocity.value + scrollEndTranslation.value;
+    const totalTranslation = scrollEndVelocityValue + panTranslation;
 
     /**
      * If the maximum scroll distance is set and the translation `exceeds the maximum scroll distance`,
@@ -374,7 +376,7 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
       translation.value = withSpring(withProcessTranslation(nextPage), onScrollEnd);
     }
     else {
-      endWithSpring(onScrollEnd);
+      endWithSpring(panTranslation, scrollEndVelocityValue, onScrollEnd);
     }
 
     if (!loop)


### PR DESCRIPTION
# What: the bug

When `endWithSpring` is called, it is using the _previous_ values for `scrollEndVelocity` and `scrollEndTranslation` (rather than the values just set in `onGestureEnd`). This seems to cause strange carousel behavior for the user: the function isn't using the values from the most recent pan.

From the user's standpoint, the problem is very obvious (and potentially frustrating) when the user pans one direction, then reverses direction for their next pan. (**Please see video demonstration below**.)

## Why

This is due to updates to shared values created via `useSharedValue()` updating asynchronously (see https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue#remarks ).

# What: proposed fix

Rather than relying on the shared data variable between function calls, let's explicitly pass the values as arguments to `endWithSpring`.

# May resolve the following issues

1. https://github.com/dohooo/react-native-reanimated-carousel/issues/535
2. https://github.com/dohooo/react-native-reanimated-carousel/issues/568
3. #579 

# Screengrab video recordings

## buggy behavior on `4.0.0-alpha.10` (unpatched)

Notice, panning the same direction works OK, but panning alternate direction fails.


https://github.com/dohooo/react-native-reanimated-carousel/assets/589004/af7ce523-57d0-4fbf-a338-741b55056c7a



## improved behavior with patch

https://github.com/dohooo/react-native-reanimated-carousel/assets/589004/55fad5c5-d702-48c8-8956-06613b014e0c


