### PR TITLE
fix: flicker when starting pan: `panOffset` value race condition

### DIFF
--- a/.changeset/spotty-melons-return.md
+++ b/.changeset/spotty-melons-return.md
@@ -1,0 +1,5 @@
+---
+'react-native-reanimated-carousel': patch
+---
+
+fix: rework code to avoid possible flicker when starting pan (panOffset race condition)

--- a/src/components/ScrollViewGesture.tsx
+++ b/src/components/ScrollViewGesture.tsx
@@ -299,7 +299,8 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
       // Keeping this value as `undefined` when it is not active protects us
       // from the situation where we may use the previous value for panOffset
       // instead; this would cause a visual flicker in the carousel.
-      console.warn("onGestureUpdate: panOffset is undefined");
+
+      // console.warn("onGestureUpdate: panOffset is undefined");
       return;
     }
 
@@ -348,7 +349,7 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
     "worklet";
 
     if (panOffset.value === undefined) {
-      console.warn("onGestureEnd: panOffset is undefined");
+      // console.warn("onGestureEnd: panOffset is undefined");
       return;
     }
 

--- a/src/components/ScrollViewGesture.tsx
+++ b/src/components/ScrollViewGesture.tsx
@@ -65,7 +65,7 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
   const maxPage = dataLength;
   const isHorizontal = useDerivedValue(() => !vertical, [vertical]);
   const max = useSharedValue(0);
-  const panOffset = useSharedValue(0);
+  const panOffset = useSharedValue<number | undefined>(undefined); // set to undefined when not actively in a pan gesture
   const touching = useSharedValue(false);
   const validStart = useSharedValue(false);
   const scrollEndTranslation = useSharedValue(0);
@@ -290,6 +290,19 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
   const onGestureUpdate = useCallback((e: PanGestureHandlerEventPayload) => {
     "worklet";
 
+    if (panOffset.value === undefined) {
+      // This may happen if `onGestureStart` is called as a part of the
+      // JS thread (instead of the UI thread / worklet). If so, when
+      // `onGestureStart` sets panOffset.value, the set will be asynchronous,
+      // and so it may not actually occur before `onGestureUpdate` is called.
+      //
+      // Keeping this value as `undefined` when it is not active protects us
+      // from the situation where we may use the previous value for panOffset
+      // instead; this would cause a visual flicker in the carousel.
+      console.warn("onGestureUpdate: panOffset is undefined");
+      return;
+    }
+
     if (validStart.value) {
       validStart.value = false;
       cancelAnimation(translation);
@@ -333,6 +346,11 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
 
   const onGestureEnd = useCallback((e: GestureStateChangeEvent<PanGestureHandlerEventPayload>, _success: boolean) => {
     "worklet";
+
+    if (panOffset.value === undefined) {
+      console.warn("onGestureEnd: panOffset is undefined");
+      return;
+    }
 
     const { velocityX, velocityY, translationX, translationY } = e;
     scrollEndVelocity.value = isHorizontal.value
@@ -379,6 +397,8 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
 
     if (!loop)
       touching.value = false;
+
+    panOffset.value = undefined;
   }, [
     size,
     loop,


### PR DESCRIPTION
# What: the bug

When `onGestureUpdate` is called, it may be using the _previous_ value for `panOffset` (rather than the value just set in `onGestureStart`). This seems to cause a flicker on slow devices since a `translation` is shown that is from a different screen.

I see this flicker most obviously on my Android simulator (**please see video demonstration below**), but the problem exists on other devices as well.

## Why

This is due to updates to shared values created via `useSharedValue()` updating asynchronously (see https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue/#remarks ).

This flicker seemed to get worse after this commit https://github.com/dohooo/react-native-reanimated-carousel/commit/b654f439e905bc1d45f5cbb1fd291f3a82848368 - "**feat: replaced onScrollBegin with onScrollStart**" (I'm not sure if there's a corresponding PR?).
This is due to the order of the handlers being triggered: `onBegin` then `onStart` then `onUpdate` ...

- _Before this commit_, the `panOffset` was saved during `onBegin` -- which would often happen much longer before `onUpdate`.
- _After this commit_, the `panOffset` is saved during `onStart` -- which might happen _immediately_ before `onUpdate` and thus may not allow enough time for the asynchronous update to occur.

# What: proposed fix

Let's add a check to make sure that `panOffset` has a valid value before we try to use it.

1. When a pan is _not_ active, `panOffset` will have a value of `undefined`.
2. (Upon pan start, in `onGestureStart`, set `panOffset` to its correct value. This is not a change from existing code.)
3. In `onGestureUpdate` and `onGestureEnd`, check to ensure that `panOffset` is not `undefined` before attempting to use it.
4. In `onGestureEnd`, reset `panOffset` to `undefined` (since pan is no longer active).

# Screengrab video recordings

These recordings were taken on an Android simulator.

## buggy behavior on `4.0.0-alpha.10` (unpatched)

Notice the flicker to a different "page" when starting pan (i.e. starting touch).

https://github.com/dohooo/react-native-reanimated-carousel/assets/589004/94d33111-2d01-42af-a182-458e83e4d086

## improved behavior with patch

https://github.com/dohooo/react-native-reanimated-carousel/assets/589004/f3cd5968-136e-433b-b5ce-152bf4720dc9



