### PR TITLE
fix: gesture `onStart`, `onUpdate`, and `onEnd` (et al) should be worklets

### DIFF
--- a/.changeset/many-ads-fry.md
+++ b/.changeset/many-ads-fry.md
@@ -1,0 +1,5 @@
+---
+'react-native-reanimated-carousel': patch
+---
+
+fix: make gesture onStart/onUpdate/onEnd (et al) callbacks run as worklets again

--- a/src/hooks/usePanGestureProxy.test.tsx
+++ b/src/hooks/usePanGestureProxy.test.tsx
@@ -140,6 +140,29 @@ describe("Using RNGH v2 gesture API", () => {
       expect.objectContaining({ translationX: 20 }),
     );
   });
+
+  it("does not include console.error in the output", () => {
+    // if react-native-gesture-handler detects that some handlers are
+    // workletized and some are not, it will log an error to the
+    // console. We'd like to make sure that this doesn't happen.
+
+    // The error that would be shown looks like:
+    // [react-native-gesture-handler] Some of the callbacks in the gesture are worklets and some are not. Either make sure that all calbacks are marked as 'worklet' if you wish to run them on the UI thread or use '.runOnJS(true)' modifier on the gesture explicitly to run all callbacks on the JS thread.
+
+    const panHandlers = mockedEventHandlers();
+    const panHandlersFromUser = mockedEventHandlersFromUser();
+
+    jest.spyOn(console, "error");
+
+    render(<SingleHandler handlers={panHandlers} handlersFromUser={panHandlersFromUser} treatStartAsUpdate />);
+    fireGestureHandler<PanGesture>(getByGestureTestId("pan"), [
+      { state: State.BEGAN },
+      { state: State.ACTIVE },
+      { state: State.END },
+    ]);
+
+    expect(console.error).not.toBeCalled();
+  });
 });
 
 describe("Event list validation", () => {

--- a/src/hooks/usePanGestureProxy.ts
+++ b/src/hooks/usePanGestureProxy.ts
@@ -78,18 +78,21 @@ export const usePanGestureProxy = (
     // Setup the original callbacks with the user defined callbacks
     gesture
       .onStart((e) => {
+        "worklet";
         onGestureStart(e);
 
         if (userDefinedConflictGestures.onStart)
           userDefinedConflictGestures.onStart(e);
       })
       .onUpdate((e) => {
+        "worklet";
         onGestureUpdate(e);
 
         if (userDefinedConflictGestures.onUpdate)
           userDefinedConflictGestures.onUpdate(e);
       })
       .onEnd((e, success) => {
+        "worklet";
         onGestureEnd(e, success);
 
         if (userDefinedConflictGestures.onEnd)

--- a/src/hooks/usePanGestureProxy.ts
+++ b/src/hooks/usePanGestureProxy.ts
@@ -27,20 +27,32 @@ export const usePanGestureProxy = (
 
     // Save the original gesture callbacks
     const originalGestures = {
+      onBegin: gesture.onBegin,
       onStart: gesture.onStart,
       onUpdate: gesture.onUpdate,
       onEnd: gesture.onEnd,
+      onFinalize: gesture.onFinalize,
     };
 
     // Save the user defined gesture callbacks
     const userDefinedConflictGestures: {
+      onBegin?: Parameters<(typeof gesture)["onBegin"]>[0]
       onStart?: Parameters<(typeof gesture)["onStart"]>[0]
       onUpdate?: Parameters<(typeof gesture)["onUpdate"]>[0]
       onEnd?: Parameters<(typeof gesture)["onEnd"]>[0]
+      onFinalize?: Parameters<(typeof gesture)["onFinalize"]>[0]
     } = {
+      onBegin: undefined,
       onStart: undefined,
       onUpdate: undefined,
       onEnd: undefined,
+      onFinalize: undefined,
+    };
+
+    const fakeOnBegin: typeof gesture.onBegin = (cb) => {
+      // Using fakeOnBegin to save the user defined callback
+      userDefinedConflictGestures.onBegin = cb;
+      return gesture;
     };
 
     const fakeOnStart: typeof gesture.onStart = (cb) => {
@@ -61,22 +73,38 @@ export const usePanGestureProxy = (
       return gesture;
     };
 
+    const fakeOnFinalize: typeof gesture.onFinalize = (cb) => {
+      // Using fakeOnFinalize to save the user defined callback
+      userDefinedConflictGestures.onFinalize = cb;
+      return gesture;
+    };
+
     // Setup the fake callbacks
+    gesture.onBegin = fakeOnBegin;
     gesture.onStart = fakeOnStart;
     gesture.onUpdate = fakeOnUpdate;
     gesture.onEnd = fakeOnEnd;
+    gesture.onFinalize = fakeOnFinalize;
 
     if (onConfigurePanGesture)
       // Get the gesture with the user defined configuration
       onConfigurePanGesture(gesture);
 
     // Restore the original callbacks
+    gesture.onBegin = originalGestures.onBegin;
     gesture.onStart = originalGestures.onStart;
     gesture.onUpdate = originalGestures.onUpdate;
     gesture.onEnd = originalGestures.onEnd;
+    gesture.onFinalize = originalGestures.onFinalize;
 
     // Setup the original callbacks with the user defined callbacks
     gesture
+      .onBegin((e) => {
+        "worklet";
+
+        if (userDefinedConflictGestures.onBegin)
+          userDefinedConflictGestures.onBegin(e);
+      })
       .onStart((e) => {
         "worklet";
         onGestureStart(e);
@@ -97,7 +125,14 @@ export const usePanGestureProxy = (
 
         if (userDefinedConflictGestures.onEnd)
           userDefinedConflictGestures.onEnd(e, success);
-      });
+      })
+      .onFinalize((e, success) => {
+        "worklet";
+
+        if (userDefinedConflictGestures.onFinalize)
+          userDefinedConflictGestures.onFinalize(e, success);
+      })
+    ;
 
     return gesture;
   }, [


### PR DESCRIPTION
# What: the bug

The `onStart`, `onUpdate`, and `onEnd` gesture handlers are not being automatically workletized. This causes these handlers to run on the JS thread instead of the UI thread, and this is causing a number of issues, including animations running more slowly and some data (via `useSharedData`) being set asynchronously, leading to some race conditions.

(See more discussion below in "Discussion of the bug".)

# What: fix the code

Add `"worklet"` directives for each gesture handler function.

# What: fix the tests

The tests (in `src/hooks/usePanGestureProxy.test.tsx`) also include `onBegin` and `onFinalize` handlers. Since the tests include these, I decided to add some functions to support them in `src/hooks/usePanGestureProxy.ts` using the same method as for `onStart`, `onUpdate`, and `onEnd`.

If some handlers for a given gesture are workletized and some are not, RNGH will show a runtime error like the following:

```
[react-native-gesture-handler] Some of the callbacks in the gesture are worklets and some are not. Either make sure that all calbacks are marked as 'worklet' if you wish to run them on the UI thread or use '.runOnJS(true)' modifier on the gesture explicitly to run all callbacks on the JS thread.
```

Let's make sure that that error doesn't appear in our tests.

**Ideally**, we could test to ensure that the handler functions actually end up workletized. This would be a good **follow-on TODO**.

# Discussion of the bug

This [lack of workletization] seems to have been accidentally introduced in:
- https://github.com/dohooo/react-native-reanimated-carousel/pull/507

In particular, the following change
https://github.com/dohooo/react-native-reanimated-carousel/pull/507/files#diff-519aac449991f2daef8d2cf263d4dcc9cb7c067210ac7e1d218cf9f31881f890L365-L368

### old code (worked to correctly workletify) - `4.0.0-alpha.5` and earlier

the handlers were set up via `Gesture.Pan().onBegin(onGestureBegin)...`

https://github.com/dohooo/react-native-reanimated-carousel/blame/5e3c3015346994eafb8c898a4ba1d345568f5ee2/src/components/ScrollViewGesture.tsx#L365-L368

Each handler function (e.g. `onGestureBegin`) was set up as a `"worklet"`, e.g. https://github.com/dohooo/react-native-reanimated-carousel/blame/5e3c3015346994eafb8c898a4ba1d345568f5ee2/src/components/ScrollViewGesture.tsx#L264-L266

### new code (borked, not automatically workletified) - `4.0.0-alpha.6` and later

the handlers are set up via `const gesture = Gesture.Pan();` then later `gesture.onStart(...` here
https://github.com/dohooo/react-native-reanimated-carousel/blob/main/src/hooks/usePanGestureProxy.ts#L79-L97

The `onStart` / `onUpdate` / `onGestureEnd` do not include the `"worklet"` directive at the start of their functions.

### But why doesn't the `react-native-reanimated/plugin` babel plugin automatically workletify these handlers?

Unfortunately, that plugin can only automatically workletify functions when they are defined via `Gesture.Pan().onStart` (or similar). The fact that we instead define `const gesture = Gesture.Pan();` in one place and then _later_ call `gesture.onStart()` / `gesture.onUpdate()` / `gesture.onEnd()` means that the babel plugin doesn't find these and automatically workletify them.

Source: https://github.com/software-mansion/react-native-reanimated/blob/main/plugin/src/gestureHandlerAutoworkletization.ts

# Screengrab video recordings

These recordings were taken on a simulator and include `console.log` output indicating whether each call to a gesture handler is running in a worklet or not. The code to output these console log messages is shown here:
- https://github.com/nmassey/react-native-reanimated-carousel/commit/21fc44a4592b84da700268afa662bd4abad7b7f2


## non-worklet behavior on `4.0.0-alpha.10` (unpatched except for `console.log` messages)

See that all debug messages indicate that the code is _not_ running inside of worklet.


https://github.com/dohooo/react-native-reanimated-carousel/assets/589004/9ff5fcea-9dfa-45a4-8da1-9705192716f0



## improved behavior with patch

See that all debug messages indicate the the code is running inside of worklet.



https://github.com/dohooo/react-native-reanimated-carousel/assets/589004/ba296f93-be06-4a44-beb3-2ce299801c2f


# possible TODOs

1. DRY up `onStart` / `onUpdate` / `onEnd` etc. code in `usePanGestureProxy.ts`
2. possibly add in other handlers? e.g. `onChange`
3. add a test to make sure the gesture handlers are workletified (I'm not sure of a good way to do this except possibly via some gray box testing, e.g. adding some code within the component to validate)
