### PR TITLE
feat/fix: better slow pan: if user intent is to stay on current page, _don't_ change page

### DIFF
--- a/.changeset/violet-chicken-hide.md
+++ b/.changeset/violet-chicken-hide.md
@@ -1,0 +1,5 @@
+---
+'react-native-reanimated-carousel': patch
+---
+
+improve "slow pan" behavior: if it seems that the user intent is to stay on the current page (because they didn't pan very far; maybe they started panning one direction then reversed direction, etc.), _don't_ actually change page upon gesture completion

--- a/src/components/ScrollViewGesture.tsx
+++ b/src/components/ScrollViewGesture.tsx
@@ -150,10 +150,11 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
           const computed = offset < 0 ? Math.ceil : Math.floor;
           const page = computed(-translation.value / size);
 
-          if (page === nextPage) {
+          const velocityDirection = -Math.sign(velocity);
+          if (page === nextPage || velocityDirection !== offset) {
             // not going anywhere! Velocity was insufficient to overcome the distance to get to a
             // further page. Let's reset gently to the current page.
-            finalTranslation = withSpring(withProcessTranslation(-nextPage * size), onFinished);
+            finalTranslation = withSpring(withProcessTranslation(-page * size), onFinished);
           }
           else if (loop) {
             const finalPage = page + offset;

--- a/src/components/ScrollViewGesture.tsx
+++ b/src/components/ScrollViewGesture.tsx
@@ -135,13 +135,27 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
         *
         * `page size` equals to `size` variable.
         * */
+
+        // calculate target "nextPage" based on the final pan position and the velocity of
+        // the pan gesture at termination; this allows for a quick "flick" to indicate a far
+        // off page change.
+        const nextPage = -Math.round((origin + velocity * 2) / size);
+
         if (pagingEnabled) {
+          // we'll never go further than a single page away from the current page when paging
+          // is enabled.
+
           // distance with direction
           const offset = -(scrollEndTranslation.value >= 0 ? 1 : -1); // 1 or -1
           const computed = offset < 0 ? Math.ceil : Math.floor;
           const page = computed(-translation.value / size);
 
-          if (loop) {
+          if (page === nextPage) {
+            // not going anywhere! Velocity was insufficient to overcome the distance to get to a
+            // further page. Let's reset gently to the current page.
+            finalTranslation = withSpring(withProcessTranslation(-nextPage * size), onFinished);
+          }
+          else if (loop) {
             const finalPage = page + offset;
             finalTranslation = withSpring(withProcessTranslation(-finalPage * size), onFinished);
           }
@@ -153,8 +167,7 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
 
         if (!pagingEnabled && snapEnabled) {
           // scroll to the nearest item
-          const nextPage = Math.round((origin + velocity * 0.4) / size) * size;
-          finalTranslation = withSpring(withProcessTranslation(nextPage), onFinished);
+          finalTranslation = withSpring(withProcessTranslation(-nextPage * size), onFinished);
         }
       }
 


### PR DESCRIPTION
# Overview

This improves swipe behavior for my full-screen carousel use case. If a user pans very slowly and ultimately not very far, we would prefer that they stay on the current page. This still allows them to "flick" to pan to the next (or previous) screen.

This should fix the following issue:
- https://github.com/dohooo/react-native-reanimated-carousel/issues/515

# Details

1. refactor code slighty: calculate `nextPage`outside of the `if` branch
2. when calculating `nextPage`, use `velocity * 2` instead of `velocity * 0.4`: I liked this factor better for my usage. This value seems to work well on all of my iOS and Android test devices
3. **fix**: if the calculated `nextPage` is actually the current page, don't go anywhere (previous behavior was to _always_ go to next or previous page)
4. **improve**: if user has mostly panned one direction, but then reverses that pan at the end of their gesture, return to current page

# Screen recording

## 👎 before patch (4.0.0-alpha.10)

Notice: panning only a little bit always brings user to the next page. This happens even if it seems that the user's intent is to stay on the current page.


https://github.com/dohooo/react-native-reanimated-carousel/assets/589004/040e6e5b-d102-49ee-9d0e-06ba9e599b79

## 👎 before patch: this version shows with some other important patches on top of 4.0.0-alpha.10: this includes #577 (worklets), #574 (useSharedValue), and #576 (panOffset)


https://github.com/dohooo/react-native-reanimated-carousel/assets/589004/67c8391e-d02b-4082-99e6-1ed0017a933c



## ✅ with this patch (also includes #577 (worklets), #574 (useSharedValue), and #576 (panOffset))

This shows good behavior with my expected user intent.


https://github.com/dohooo/react-native-reanimated-carousel/assets/589004/2187c95a-c3b8-4409-87f8-e77fe30926d5

