### PR TITLE
fix: typescript error where MeasuredDimension can be null

### DIFF
--- a/src/components/ScrollViewGesture.tsx
+++ b/src/components/ScrollViewGesture.tsx
@@ -79,7 +79,8 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
     "worklet";
 
     if (!loop && !overscrollEnabled) {
-      const { width: containerWidth = 0 } = measure(containerRef);
+      const measurement = measure(containerRef);
+      const containerWidth = measurement?.width || 0;
 
       // If the item's total width is less than the container's width, then there is no need to scroll.
       if (dataLength * size < containerWidth)


### PR DESCRIPTION
## Bug:
we updated react-native-reanimated-carousel to version `v4.0.0-alpha.12` in our project and ran into this type error in `ScrollViewGesture.tsx`:

![image](https://github.com/dohooo/react-native-reanimated-carousel/assets/56660727/dba5f516-88e9-427b-80cc-f2e89d6edc95)

## Fix:
added a null check to the MeasuredDimension, with a default of `0`