### PR TITLE
fix: rotateZDeg not working when passed through modeConfig in horizontal-stack mode

### DIFF
--- a/src/layouts/stack.ts
+++ b/src/layouts/stack.ts
@@ -88,7 +88,7 @@ export function horizontalStackLayout(modeConfig: ILayoutConfig = {}) {
       rotateZ = `${interpolate(
         value,
         inputRange,
-        [-rotateZDeg, 0, 0],
+        [0, value * rotateZDeg, value * rotateZDeg],
         Extrapolate.CLAMP,
       )}deg`;
     }
@@ -108,7 +108,7 @@ export function horizontalStackLayout(modeConfig: ILayoutConfig = {}) {
       rotateZ = `${interpolate(
         value,
         inputRange,
-        [0, 0, rotateZDeg],
+        [value * rotateZDeg, value * rotateZDeg, 0],
         Extrapolate.CLAMP,
       )}deg`;
     }


### PR DESCRIPTION
Bug: 

rotateZDeg does not works when passed in horizontal-stack mode through modeConfig.

Fixes:

calculation for rotateZDeg in snap direction left and right