### PR TITLE
fix: fix carousel sizing

### DIFF
--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -153,7 +153,12 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
     const layoutConfig = useLayoutConfig({ ...props, size });
 
     return (
-      <GestureHandlerRootView>
+      <GestureHandlerRootView
+        style={{
+          width: width || "100%",
+          height: height || "100%",
+        }}
+      >
         <CTX.Provider value={{ props, common: commonVariables }}>
           <ScrollViewGesture
             key={mode}
@@ -161,10 +166,6 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
             translation={handlerOffset}
             style={[
               styles.container,
-              {
-                width: width || "100%",
-                height: height || "100%",
-              },
               style,
               vertical ? styles.itemsVertical : styles.itemsHorizontal,
             ]}
@@ -202,6 +203,7 @@ export default Carousel as <T extends any>(
 const styles = StyleSheet.create({
   container: {
     overflow: "hidden",
+    flex: 1,
   },
   itemsHorizontal: {
     flexDirection: "row",


### PR DESCRIPTION
Closes #646 

In `react-native-gesture-handler` [v2.16.0](https://github.com/software-mansion/react-native-gesture-handler/releases/tag/2.16.0), a style of `{flex: 1}` was added to `GestureHandlerRootView` in [this pr](https://github.com/software-mansion/react-native-gesture-handler/pull/2757).

This styling leads to the issues mentioned in #646 

In order to fix the issue, the `width` and `height` are set on the `GestureHandlerRootView` and the container has a `flex: 1` to fill in the `GestureHandlerRootView`