### PR TITLE
fix: typeof "function" onProgressChange - fixes app crash

### DIFF
--- a/.changeset/nine-moose-whisper.md
+++ b/.changeset/nine-moose-whisper.md
@@ -1,0 +1,5 @@
+---
+"react-native-reanimated-carousel": patch
+---
+
+fix app crash when using "onProgressChange" prop as function

--- a/src/hooks/useOnProgressChange.ts
+++ b/src/hooks/useOnProgressChange.ts
@@ -19,8 +19,10 @@ export function useOnProgressChange(
   const { autoFillData, loop, offsetX, size, rawDataLength, onProgressChange }
         = opts;
 
-  // remember this here because we can't check it inside useAnimatedReaction
-  // because of how reanimated's threading works.
+  // remember `isFunc` here because we can't accurately check typeof
+  // from within useAnimatedReaction because its code has been workletized;
+  // the `onProgressChange` value will be typeof "object" from within
+  // the worklet code even if it's a function.
   const isFunc = typeof onProgressChange === "function";
 
   useAnimatedReaction(

--- a/src/hooks/useOnProgressChange.ts
+++ b/src/hooks/useOnProgressChange.ts
@@ -19,6 +19,10 @@ export function useOnProgressChange(
   const { autoFillData, loop, offsetX, size, rawDataLength, onProgressChange }
         = opts;
 
+  // remember this here because we can't check it inside useAnimatedReaction
+  // because of how reanimated's threading works.
+  const isFunc = typeof onProgressChange === "function";
+
   useAnimatedReaction(
     () => offsetX.value,
     (_value) => {
@@ -43,7 +47,7 @@ export function useOnProgressChange(
         absoluteProgress = rawDataLength - absoluteProgress;
 
       if (onProgressChange) {
-        if (typeof onProgressChange === "function")
+        if (isFunc)
           runOnJS(onProgressChange)(value, absoluteProgress);
 
         else


### PR DESCRIPTION
# What: the bug

On iOS, when running in "Release" configuration (i.e. not "development" configuration), if `onProgressChange` is a function, **the app crashes**. 😖

On Android, similar **crash**. Thanks to @yannick-softwerft for providing a traceback in [a comment below](https://github.com/dohooo/react-native-reanimated-carousel/pull/648#issuecomment-2256481543).

This bug was accidentally introduced in 0d2b930f394f65fd70a03593ea8c7b16fb552e62 (in [code here](https://github.com/dohooo/react-native-reanimated-carousel/commit/0d2b930f394f65fd70a03593ea8c7b16fb552e62#diff-76055baf1d987bd60cfcbc19200ec53038a6ee44972a224e112ad5869528779bR46-R50))

## Why

Since the callback functions in `useAnimatedReaction` [are automatically workletized](https://docs.swmansion.com/react-native-reanimated/docs/advanced/useAnimatedReaction#remarks), when running in Xcode "Release" configuration (i.e. not "development" configuration), if the variable `onProgressChange` is set to a function (from within the JS thread), then `typeof onProgressChange` will be equal to `"object"` from within the workletized function (in the UI thread).

So, the code assumes that the value is a SharedValue and attempts to set `onProgressChange.value = absoluteProgress`. However, this seems to immediately cause the app to crash.

### My configuration

1. expo: 50.0.19
2. react-native-reanimated: 3.6.2
3. react-native-reanimated-carousel: 4.0.0-alpha.12

# What: the fix

Remember the value for `typeof onProgressChange` in the JS thread (instead trying to check it from within the UI thread).

App no longer crashes! And `onProgressChange` as function works correctly again!! 🥳🙌