### PR TITLE
feat: add `onEndWithSpring` event

### DIFF
--- a/example/app/src/pages/normal/index.tsx
+++ b/example/app/src/pages/normal/index.tsx
@@ -49,6 +49,7 @@ function Index() {
         data={data}
         onScrollStart={()=>{console.log('===1')}}
         onScrollEnd={()=>{console.log('===2')}}
+        onEndWithSpring={(index: number)=>{console.log(`onEndWithSpring ${index}`)}}
 
         onConfigurePanGesture={g => g.enabled(false)}
         pagingEnabled={isPagingEnabled}

--- a/src/hooks/useCarouselController.tsx
+++ b/src/hooks/useCarouselController.tsx
@@ -29,6 +29,7 @@ interface IOpts {
   defaultIndex?: number
   onScrollStart?: () => void
   onScrollEnd?: () => void
+  onEndWithSpring?: (index: number) => void
 }
 
 export interface ICarouselController {
@@ -142,6 +143,10 @@ export function useCarouselController(options: IOpts): ICarouselController {
     options.onScrollStart?.();
   }, [options]);
 
+  const onEndWithSpring = React.useCallback((index: number) => {
+    options.onEndWithSpring?.(index);
+  }, [options]);
+
   const scrollWithTiming = React.useCallback(
     (toValue: number, onFinished?: () => void) => {
       "worklet";
@@ -173,9 +178,11 @@ export function useCarouselController(options: IOpts): ICarouselController {
       if (!canSliding() || (!loop && index.value >= dataInfo.length - 1))
         return;
 
-      onScrollStart?.();
-
       const nextPage = currentFixedPage() + count;
+
+      onScrollStart?.();
+      onEndWithSpring?.(nextPage);
+
       index.value = nextPage;
 
       if (animated) {
@@ -195,6 +202,7 @@ export function useCarouselController(options: IOpts): ICarouselController {
       index,
       dataInfo,
       onScrollStart,
+      onEndWithSpring,
       handlerOffset,
       size,
       scrollWithTiming,
@@ -207,9 +215,11 @@ export function useCarouselController(options: IOpts): ICarouselController {
       const { count = 1, animated = true, onFinished } = opts;
       if (!canSliding() || (!loop && index.value <= 0)) return;
 
-      onScrollStart?.();
-
       const prevPage = currentFixedPage() - count;
+
+      onScrollStart?.();
+      onEndWithSpring?.(prevPage);
+
       index.value = prevPage;
 
       if (animated) {
@@ -228,6 +238,7 @@ export function useCarouselController(options: IOpts): ICarouselController {
       loop,
       index,
       onScrollStart,
+      onEndWithSpring,
       handlerOffset,
       size,
       scrollWithTiming,

--- a/src/types.ts
+++ b/src/types.ts
@@ -192,6 +192,10 @@ export type TCarouselProps<T = any> = {
       */
   onScrollEnd?: (index: number) => void
   /**
+      * On end with spring
+      */
+  onEndWithSpring?: (index: number) => void
+  /**
       * On progress change
       * @param offsetProgress Total of offset distance (0 390 780 ...)
       * @param absoluteProgress Convert to index (0 1 2 ...)


### PR DESCRIPTION
Fires `onEndWithSpring` on Carousel starts to spring to index.

This is useful when user wants to get event when Carousel starts to spring to index.