### PR TITLE
Change TouchableWithoutFeedback import

### DIFF
--- a/src/components/Pagination/Basic/index.tsx
+++ b/src/components/Pagination/Basic/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import type { StyleProp, ViewStyle } from "react-native";
+import type { StyleProp, ViewStyle, TouchableWithoutFeedback } from "react-native";
 import { View } from "react-native";
-import { TouchableWithoutFeedback } from "react-native-gesture-handler";
 import type { SharedValue } from "react-native-reanimated";
 
 import type { DotStyle } from "./PaginationItem";


### PR DESCRIPTION
Import TouchableWithoutFeedback from react-native instead of react-native-gesture-handler to solve Error: NativeViewGestureHandler must be used as a descendant of GestureHandlerRootView