### PR TITLE
fix: PaginationItem onPress (both Pagination.Basic and Pagination.Custom)

### DIFF
--- a/.changeset/cyan-pillows-swim.md
+++ b/.changeset/cyan-pillows-swim.md
@@ -1,0 +1,6 @@
+---
+"react-native-reanimated-carousel": patch
+---
+
+fix Pagination.Basic and Pagination.Custom usage of TouchableWithoutFeedback.
+This fixes press event handler not working correctly. (Thanks to @qwertychouskie for reporting!)

--- a/src/components/Pagination/Basic/PaginationItem.tsx
+++ b/src/components/Pagination/Basic/PaginationItem.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from "react";
 import React from "react";
 import type { ViewStyle } from "react-native";
-import { View } from "react-native";
+import { TouchableWithoutFeedback, View } from "react-native";
 import Animated, {
   Extrapolation,
   interpolate,
@@ -22,6 +22,7 @@ PropsWithChildren<{
   horizontal?: boolean
   dotStyle?: DotStyle
   activeDotStyle?: DotStyle
+  onPress: () => void
 }>
 > = (props) => {
   const {
@@ -33,6 +34,7 @@ PropsWithChildren<{
     size,
     horizontal,
     children,
+    onPress,
   } = props;
 
   const defaultDotSize = 10;
@@ -79,8 +81,9 @@ PropsWithChildren<{
   }, [animValue, index, count, horizontal]);
 
   return (
-    <View
-      style={[
+    <TouchableWithoutFeedback onPress={onPress}>
+      <View
+        style={[
         {
           width,
           height,
@@ -105,7 +108,8 @@ PropsWithChildren<{
         ]}
       >
         {children}
-      </Animated.View>
-    </View>
+          </Animated.View>
+      </View>
+    </TouchableWithoutFeedback>
   );
 };

--- a/src/components/Pagination/Basic/PaginationItem.tsx
+++ b/src/components/Pagination/Basic/PaginationItem.tsx
@@ -84,31 +84,31 @@ PropsWithChildren<{
     <TouchableWithoutFeedback onPress={onPress}>
       <View
         style={[
-        {
-          width,
-          height,
-          overflow: "hidden",
-          transform: [
-            {
-              rotateZ: horizontal ? "90deg" : "0deg",
-            },
-          ],
-        },
-        dotStyle,
-      ]}
-    >
-      <Animated.View
-        style={[
           {
-            backgroundColor: "black",
-            flex: 1,
+            width,
+            height,
+            overflow: "hidden",
+            transform: [
+              {
+                rotateZ: horizontal ? "90deg" : "0deg",
+              },
+            ],
           },
-          animStyle,
-          activeDotStyle,
-        ]}
+          dotStyle,
+      ]}
       >
-        {children}
-          </Animated.View>
+        <Animated.View
+          style={[
+            {
+              backgroundColor: "black",
+              flex: 1,
+            },
+            animStyle,
+            activeDotStyle,
+          ]}
+        >
+          {children}
+        </Animated.View>
       </View>
     </TouchableWithoutFeedback>
   );

--- a/src/components/Pagination/Basic/index.tsx
+++ b/src/components/Pagination/Basic/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { StyleProp, ViewStyle } from "react-native";
-import { View, TouchableWithoutFeedback } from "react-native";
+import { View } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
 
 import type { DotStyle } from "./PaginationItem";
@@ -57,11 +57,8 @@ export const Basic = <T extends {}>(props: BasicProps<T>) => {
     >
       {data.map((item, index) => {
         return (
-          <TouchableWithoutFeedback
-            key={index}
-            onPress={() => onPress?.(index)}
-          >
             <PaginationItem
+            key={index}
               index={index}
               size={size}
               count={data.length}
@@ -69,10 +66,10 @@ export const Basic = <T extends {}>(props: BasicProps<T>) => {
               animValue={progress}
               horizontal={!horizontal}
               activeDotStyle={activeDotStyle}
-            >
+              onPress={() => onPress?.(index)}
+              >
               {renderItem?.(item, index)}
             </PaginationItem>
-          </TouchableWithoutFeedback>
         );
       })}
     </View>

--- a/src/components/Pagination/Basic/index.tsx
+++ b/src/components/Pagination/Basic/index.tsx
@@ -57,20 +57,20 @@ export const Basic = <T extends {}>(props: BasicProps<T>) => {
     >
       {data.map((item, index) => {
         return (
-            <PaginationItem
+          <PaginationItem
             key={index}
-              index={index}
-              size={size}
-              count={data.length}
-              dotStyle={dotStyle}
-              animValue={progress}
-              horizontal={!horizontal}
-              activeDotStyle={activeDotStyle}
-              onPress={() => onPress?.(index)}
-              >
-              {renderItem?.(item, index)}
-            </PaginationItem>
-        );
+            index={index}
+            size={size}
+            count={data.length}
+            dotStyle={dotStyle}
+            animValue={progress}
+            horizontal={!horizontal}
+            activeDotStyle={activeDotStyle}
+            onPress={() => onPress?.(index)}
+          >
+            {renderItem?.(item, index)}
+          </PaginationItem>
+      );
       })}
     </View>
   );

--- a/src/components/Pagination/Custom/PaginationItem.tsx
+++ b/src/components/Pagination/Custom/PaginationItem.tsx
@@ -130,20 +130,20 @@ export const PaginationItem: React.FC<
 
   return (
     <TouchableWithoutFeedback onPress={onPress}>
-    <Animated.View
-      style={[
-        {
-          overflow: "hidden",
-          transform: [
-            {
-              rotateZ: horizontal ? "90deg" : "0deg",
-            },
-          ],
-        },
-        dotStyle,
-        animStyle,
-      ]}
-    >
+      <Animated.View
+        style={[
+          {
+            overflow: "hidden",
+            transform: [
+              {
+                rotateZ: horizontal ? "90deg" : "0deg",
+              },
+            ],
+          },
+          dotStyle,
+          animStyle,
+        ]}
+      >
         {children}
       </Animated.View>
     </TouchableWithoutFeedback>

--- a/src/components/Pagination/Custom/PaginationItem.tsx
+++ b/src/components/Pagination/Custom/PaginationItem.tsx
@@ -1,5 +1,6 @@
 import type { PropsWithChildren } from "react";
 import React from "react";
+import { TouchableWithoutFeedback } from "react-native";
 import type { ViewStyle } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
 import Animated, {
@@ -33,6 +34,7 @@ export const PaginationItem: React.FC<
     horizontal?: boolean;
     dotStyle?: DotStyle;
     activeDotStyle?: DotStyle;
+    onPress: () => void;
     customReanimatedStyle?: (
       progress: number,
       index: number,
@@ -51,6 +53,7 @@ export const PaginationItem: React.FC<
     horizontal,
     children,
     customReanimatedStyle,
+    onPress,
   } = props;
   const customReanimatedStyleRef = useSharedValue<DefaultStyle>({});
   const handleCustomAnimation = (progress: number) => {
@@ -126,6 +129,7 @@ export const PaginationItem: React.FC<
   ]);
 
   return (
+    <TouchableWithoutFeedback onPress={onPress}>
     <Animated.View
       style={[
         {
@@ -140,7 +144,8 @@ export const PaginationItem: React.FC<
         animStyle,
       ]}
     >
-      {children}
-    </Animated.View>
+        {children}
+      </Animated.View>
+    </TouchableWithoutFeedback>
   );
 };

--- a/src/components/Pagination/Custom/index.tsx
+++ b/src/components/Pagination/Custom/index.tsx
@@ -72,20 +72,20 @@ export const Custom = <T extends {}>(props: ShapeProps<T>) => {
     >
       {data.map((item, index) => {
         return (
-            <PaginationItem
+          <PaginationItem
             key={index}
             index={index}
-              size={size}
-              count={data.length}
-              dotStyle={dotStyle}
-              animValue={progress}
-              horizontal={!horizontal}
-              activeDotStyle={activeDotStyle}
-              customReanimatedStyle={customReanimatedStyle}
-              onPress={() => onPress?.(index)}
-              >
-              {renderItem?.(item, index)}
-            </PaginationItem>
+            size={size}
+            count={data.length}
+            dotStyle={dotStyle}
+            animValue={progress}
+            horizontal={!horizontal}
+            activeDotStyle={activeDotStyle}
+            customReanimatedStyle={customReanimatedStyle}
+            onPress={() => onPress?.(index)}
+          >
+            {renderItem?.(item, index)}
+          </PaginationItem>
         );
       })}
     </View>

--- a/src/components/Pagination/Custom/index.tsx
+++ b/src/components/Pagination/Custom/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { StyleProp, ViewStyle } from "react-native";
-import { TouchableWithoutFeedback, View } from "react-native";
+import { View } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
 
 import type { DefaultStyle } from "react-native-reanimated/lib/typescript/hook/commonTypes";
@@ -72,12 +72,9 @@ export const Custom = <T extends {}>(props: ShapeProps<T>) => {
     >
       {data.map((item, index) => {
         return (
-          <TouchableWithoutFeedback
-            key={index}
-            onPress={() => onPress?.(index)}
-          >
             <PaginationItem
-              index={index}
+            key={index}
+            index={index}
               size={size}
               count={data.length}
               dotStyle={dotStyle}
@@ -85,10 +82,10 @@ export const Custom = <T extends {}>(props: ShapeProps<T>) => {
               horizontal={!horizontal}
               activeDotStyle={activeDotStyle}
               customReanimatedStyle={customReanimatedStyle}
-            >
+              onPress={() => onPress?.(index)}
+              >
               {renderItem?.(item, index)}
             </PaginationItem>
-          </TouchableWithoutFeedback>
         );
       })}
     </View>

--- a/src/components/Pagination/Custom/index.tsx
+++ b/src/components/Pagination/Custom/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import type { StyleProp, ViewStyle } from "react-native";
-import { View } from "react-native";
-import { TouchableWithoutFeedback } from "react-native-gesture-handler";
+import { TouchableWithoutFeedback, View } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
 
 import type { DefaultStyle } from "react-native-reanimated/lib/typescript/hook/commonTypes";


### PR DESCRIPTION
# Overview of the bug

As per #676, [v4.0.0-canary.13](https://github.com/dohooo/react-native-reanimated-carousel/releases/tag/v4.0.0-canary.13) accidentally introduced a bug that caused the click events on `Pagination.Basic` to no longer work.

This appears to have been accidentally introduced in #655

Thanks to @qwertychouskie for reporting here:
- #676 

## Why

From the [TouchableWithoutFeedback](https://reactnative.dev/docs/touchablewithoutfeedback) docs:

> Importantly, `TouchableWithoutFeedback` works by cloning its child and applying responder props to it. It is therefore required that any intermediary components pass through those props to the underlying React Native component.

# What: the fix

1. in `Pagination.Custom`, standardize by importing `TouchableWithoutFeedback` from `react-native` (like we already do for `Pagination.Basic`)
2. for both `Pagination.Basic` and `Pagination.Custom`, lower the `<TouchableWithoutFeedback>` wrapper to inside of `PaginationItem` so that it is immediately around the target `<View>` (or `<Animated.View>`) instead

## Why

When using `TouchableWithoutFeedback`, it's important to keep `<TouchableWithoutFeedback>` immediately around the child `<View>` component. 

# Suggestion for reviewer

As a bulk of the changeset is just whitespace changes, I suggest reviewing this PR with whitespace hidden -

<img width="336" alt="image" src="https://github.com/user-attachments/assets/53ef7cb6-b792-497c-820b-a7193115be78">

