### PR TITLE
feat: add `itemContainerStyle` to handle styles on whole item container

### DIFF
--- a/src/components/BaseLayout.tsx
+++ b/src/components/BaseLayout.tsx
@@ -1,17 +1,14 @@
-import React from "react";
+import React from 'react';
+import Animated, { useAnimatedStyle, useDerivedValue } from 'react-native-reanimated';
+
+import { useOffsetX } from '../hooks/useOffsetX';
+import { CTX } from '../store';
+
 import type { ViewStyle } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
-import Animated, {
-  useAnimatedStyle,
-  useDerivedValue,
-} from "react-native-reanimated";
-
 import type { IOpts } from "../hooks/useOffsetX";
-import { useOffsetX } from "../hooks/useOffsetX";
 import type { IVisibleRanges } from "../hooks/useVisibleRanges";
 import type { ILayoutConfig } from "../layouts/stack";
-import { CTX } from "../store";
-
 export type TAnimationStyle = (value: number) => ViewStyle;
 
 export const BaseLayout: React.FC<{
@@ -19,11 +16,12 @@ export const BaseLayout: React.FC<{
   handlerOffset: SharedValue<number>;
   visibleRanges: IVisibleRanges;
   animationStyle: TAnimationStyle;
+  itemContainerStyle?: ViewStyle
   children: (ctx: {
     animationValue: Animated.SharedValue<number>;
   }) => React.ReactElement;
 }> = (props) => {
-  const { handlerOffset, index, children, visibleRanges, animationStyle } =
+  const { handlerOffset, index, children, visibleRanges, animationStyle, itemContainerStyle } =
     props;
 
   const context = React.useContext(CTX);
@@ -80,6 +78,7 @@ export const BaseLayout: React.FC<{
           position: "absolute",
         },
         animatedStyle,
+        itemContainerStyle,
       ]}
       /**
        * We use this testID to know when the carousel item is ready to be tested in test.

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -1,22 +1,21 @@
-import React from "react";
-import { StyleSheet } from "react-native";
-import { GestureHandlerRootView } from "react-native-gesture-handler";
-import { runOnJS, useDerivedValue } from "react-native-reanimated";
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { runOnJS, useDerivedValue } from 'react-native-reanimated';
 
-import { ItemRenderer } from "./ItemRenderer";
-import { ScrollViewGesture } from "./ScrollViewGesture";
+import { useAutoPlay } from '../hooks/useAutoPlay';
+import { useCarouselController } from '../hooks/useCarouselController';
+import { useCommonVariables } from '../hooks/useCommonVariables';
+import { useInitProps } from '../hooks/useInitProps';
+import { useLayoutConfig } from '../hooks/useLayoutConfig';
+import { useOnProgressChange } from '../hooks/useOnProgressChange';
+import { usePropsErrorBoundary } from '../hooks/usePropsErrorBoundary';
+import { CTX } from '../store';
+import { computedRealIndexWithAutoFillData } from '../utils/computed-with-auto-fill-data';
+import { ItemRenderer } from './ItemRenderer';
+import { ScrollViewGesture } from './ScrollViewGesture';
 
-import { useAutoPlay } from "../hooks/useAutoPlay";
-import { useCarouselController } from "../hooks/useCarouselController";
-import { useCommonVariables } from "../hooks/useCommonVariables";
-import { useInitProps } from "../hooks/useInitProps";
-import { useLayoutConfig } from "../hooks/useLayoutConfig";
-import { useOnProgressChange } from "../hooks/useOnProgressChange";
-import { usePropsErrorBoundary } from "../hooks/usePropsErrorBoundary";
-import { CTX } from "../store";
 import type { ICarouselInstance, TCarouselProps } from "../types";
-import { computedRealIndexWithAutoFillData } from "../utils/computed-with-auto-fill-data";
-
 const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
   (_props, ref) => {
     const props = useInitProps(_props);
@@ -50,6 +49,7 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
       onProgressChange,
       customAnimation,
       defaultIndex,
+      itemContainerStyle
     } = props;
 
     const commonVariables = useCommonVariables(props);
@@ -187,6 +187,7 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
               layoutConfig={layoutConfig}
               renderItem={renderItem}
               customAnimation={customAnimation}
+              itemContainerStyle={itemContainerStyle}
             />
           </ScrollViewGesture>
         </CTX.Provider>

--- a/src/components/ItemRenderer.tsx
+++ b/src/components/ItemRenderer.tsx
@@ -1,17 +1,16 @@
-import React from "react";
+import React from 'react';
+import { runOnJS, useAnimatedReaction } from 'react-native-reanimated';
+
+import { useVisibleRanges } from '../hooks/useVisibleRanges';
+import { computedRealIndexWithAutoFillData } from '../utils/computed-with-auto-fill-data';
+import { BaseLayout } from './BaseLayout';
+
 import type { FC } from "react";
 import type { ViewStyle } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
-import { useAnimatedReaction, runOnJS } from "react-native-reanimated";
-
-import type { TAnimationStyle } from "./BaseLayout";
-import { BaseLayout } from "./BaseLayout";
-
 import type { VisibleRanges } from "../hooks/useVisibleRanges";
-import { useVisibleRanges } from "../hooks/useVisibleRanges";
 import type { CarouselRenderItem } from "../types";
-import { computedRealIndexWithAutoFillData } from "../utils/computed-with-auto-fill-data";
-
+import type { TAnimationStyle } from "./BaseLayout";
 interface Props {
   data: any[];
   dataLength: number;
@@ -25,6 +24,7 @@ interface Props {
   layoutConfig: TAnimationStyle;
   renderItem: CarouselRenderItem<any>;
   customAnimation?: (value: number) => ViewStyle;
+  itemContainerStyle?: ViewStyle
 }
 
 export const ItemRenderer: FC<Props> = (props) => {
@@ -41,6 +41,7 @@ export const ItemRenderer: FC<Props> = (props) => {
     layoutConfig,
     renderItem,
     customAnimation,
+    itemContainerStyle
   } = props;
 
   const visibleRanges = useVisibleRanges({
@@ -88,6 +89,7 @@ export const ItemRenderer: FC<Props> = (props) => {
             handlerOffset={offsetX}
             visibleRanges={visibleRanges}
             animationStyle={customAnimation || layoutConfig}
+            itemContainerStyle={itemContainerStyle}
           >
             {({ animationValue }) =>
               renderItem({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,11 @@
 import type { StyleProp, ViewStyle } from "react-native";
 import type { PanGesture } from "react-native-gesture-handler";
+import type Animated from "react-native-reanimated";
 import type {
   SharedValue,
   WithSpringConfig,
   WithTimingConfig,
 } from "react-native-reanimated";
-import type Animated from "react-native-reanimated";
 
 import type { TParallaxModeProps } from "./layouts/parallax";
 import type { TStackModeProps } from "./layouts/stack";
@@ -209,6 +209,7 @@ export type TCarouselProps<T = any> = {
       * @deprecated please use snapEnabled instead
       */
   enableSnap?: boolean
+  itemContainerStyle?: ViewStyle
 } & (TParallaxModeProps | TStackModeProps);
 
 export interface ICarouselInstance {


### PR DESCRIPTION
I ran into a problem when I needed to implement the effect of layering images in a carousel. However, I noticed that I have no control over the styles of the container itself. Example picture below
![photo_2024-09-17_22-01-03](https://github.com/user-attachments/assets/4d6e9601-d929-4bf1-bed7-5b3c84345c92)
