### PR TITLE
fix: dependency array; removes shared value access warning from react-native-reanimated

### DIFF
--- a/.changeset/rare-insects-camp.md
+++ b/.changeset/rare-insects-camp.md
@@ -1,0 +1,5 @@
+---
+"react-native-reanimated-carousel": patch
+---
+
+fix: remove shared value access warning from react-native-reanimated

--- a/src/components/ScrollViewGesture.tsx
+++ b/src/components/ScrollViewGesture.tsx
@@ -205,7 +205,7 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
       { velocity: scrollEndVelocity.value },
       isFinished => onFinish(isFinished as boolean),
     );
-  }, [onFinish, scrollEndVelocity.value, touching, translation]);
+  }, [onFinish, scrollEndVelocity, touching, translation]);
 
   const resetBoundary = React.useCallback(() => {
     "worklet";

--- a/src/components/ScrollViewGesture.tsx
+++ b/src/components/ScrollViewGesture.tsx
@@ -232,11 +232,11 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
         translation.value = withSpring(-((maxPage - 1) * size));
     }
   }, [
-    touching.value,
+    touching,
     translation,
     maxPage,
     size,
-    scrollEndTranslation.value,
+    scrollEndTranslation,
     loop,
     activeDecay,
     withSpring,


### PR DESCRIPTION
Fixes #706

# What: the bug

## Where in our code

In `ScrollViewGesture.tsx`, we had included `touching.value` and `scrollEndTranslation.value` in the dependency arrays for a couple of React callbacks. Not only is this not necessary, but it also causes a warning message to appear (and introduces the potential performance implication mentioned below).

These dependency array `.value`s were introduced in https://github.com/dohooo/react-native-reanimated-carousel/commit/eb21293d6c0544da9e62a418505945dc46a59cb6 (as a part of #116).

## Warning message in react-native-reanimated

As per #706 (thank you, @joaofelippe911), a console warning appears when using react-native-reanimated version 3.16.0 or higher. This new warning was added via https://github.com/software-mansion/react-native-reanimated/pull/6310

The warning looks like:

```
 WARN  [Reanimated] Reading from `value` during component render. Please ensure that you do not access the `value` property or use `get` method of a shared value while React is rendering a component.

If you don't want to see this message, you can disable the `strict` mode. Refer to:
https://docs.swmansion.com/react-native-reanimated/docs/debugging/logger-configuration for more details.
```

### Why: potential performance implication

As per https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue/#remarks ,

> When you read the `sv.value` on the [JavaScript thread](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#javascript-thread), the thread will get blocked until the value is fetched from the [UI thread](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#ui-thread). In most cases it will be negligible, but if the UI thread is busy or you are reading a value multiple times, the wait time needed to synchronize both threads may significantly increase.

# What: the fix

Don't depend on `touching.value` and `scrollEndTranslation.value` in our dependency arrays in `useCallback()`.

These aren't needed: all accesses to `touching.value` and `scrollEndTranslation.value` are within worklets, and as per https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue/#remarks :

> When you change the `sv.value` the update will happen synchronously on the [UI thread](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#ui-thread).

## Verification: in local testing, the warning disappears!

In my local testing, this makes the warning disappear completely! And the carousel still behaves as normal.

## Aside: where is this code used anyway?

In `ScrollViewGesture`, there is a `useAnimatedReaction()` which calls `resetBoundary()` for changes to `translation.value` whenever `pagingEnabled` is `false`.

`resetBoundary()` calls `activeDecay()` in some cases... which in turn calls `onFinish()` in some cases.

It is worth noting that `onFinish`, `activeDecay`, and `resetBoundary` are _only_ ever used when `pagingEnabled` is `false`.

(After a few minutes of playing around with my code for my use case, I was not able to cause `activeDecay()` to ever run.)
