### PR TITLE
fix: parallax layout with new arch enabled

### DIFF
--- a/src/layouts/parallax.ts
+++ b/src/layouts/parallax.ts
@@ -52,11 +52,13 @@ export function parallaxLayout(
       [-size + parallaxScrollingOffset, 0, size - parallaxScrollingOffset],
     );
 
-    const zIndex = interpolate(
-      value,
-      [-1, 0, 1],
-      [0, size, 0],
-      Extrapolation.CLAMP,
+    const zIndex = Math.round(
+      interpolate(
+        value,
+        [-1, 0, 1],
+        [0, size, 0],
+        Extrapolation.CLAMP,
+      )
     );
 
     const scale = interpolate(


### PR DESCRIPTION
<!-- Is this PR related to an open issue? -->

This PR fixes #715, #712 

<!-- GitHub: Fixes #0, Relates to #1, etc. -->

### Description

Round the zIndex value in the parallax layout

### Review

- [x] I self-reviewed this PR

<!-- Call out any changes that you'd like people to review or feedback on -->

### Testing

- I manually tested
