### PR TITLE
fix: add pointerEvents: ‘box-none’ to ItemLayout

### DIFF
--- a/src/components/ItemLayout.tsx
+++ b/src/components/ItemLayout.tsx
@@ -73,6 +73,7 @@ export const ItemLayout: React.FC<{
           width: width || "100%",
           height: height || "100%",
           position: "absolute",
+          pointerEvents: "box-none",
         },
         animatedStyle,
       ]}


### PR DESCRIPTION
### Description

* Add pointerEvents: ‘box-none’ to ItemLayout component to allow touches for children components outside item boundaries

### Review
- [X] I self-reviewed this PR