### PR TITLE
fix: better slow pan: if user intent is to stay on current page, _don't_ change page

### DIFF
--- a/.changeset/wise-drinks-explode.md
+++ b/.changeset/wise-drinks-explode.md
@@ -1,0 +1,5 @@
+---
+"react-native-reanimated-carousel": patch
+---
+
+improve "slow pan" behavior: if it seems that the user intent is to stay on the current page (because they didn't pan very far; maybe they started panning one direction then reversed direction, etc.), _don't_ actually change page upon gesture completion

--- a/biome.json
+++ b/biome.json
@@ -53,6 +53,8 @@
       "example/app/node_modules/**/*",
       "example/app/metro.config.js",
       "example/app/babel.config.js",
+      "example/app/ios/**/*",
+      "example/app/android/**/*",
       "scripts/**/*",
       "package.json"
     ]

--- a/example/app/app/demos/basic-layouts/left-align/index.tsx
+++ b/example/app/app/demos/basic-layouts/left-align/index.tsx
@@ -1,5 +1,6 @@
 import { CarouselAdvancedSettingsPanel } from "@/components/CarouselAdvancedSettingsPanel";
 import { defaultDataWith6Colors } from "@/components/CarouselBasicSettingsPanel";
+import { window } from "@/constants/sizes";
 import { useAdvancedSettings } from "@/hooks/useSettings";
 import { CaptureWrapper } from "@/store/CaptureProvider";
 import { renderItem } from "@/utils/render-item";
@@ -22,7 +23,7 @@ function Index() {
       pagingEnabled: true,
       snapEnabled: true,
       vertical: false,
-      width: 430,
+      width: window.width,
     },
   });
 

--- a/example/app/app/demos/basic-layouts/normal/index.tsx
+++ b/example/app/app/demos/basic-layouts/normal/index.tsx
@@ -1,5 +1,6 @@
 import { CarouselAdvancedSettingsPanel } from "@/components/CarouselAdvancedSettingsPanel";
 import { defaultDataWith6Colors } from "@/components/CarouselBasicSettingsPanel";
+import { MAX_WIDTH, window } from "@/constants/sizes";
 import { useAdvancedSettings } from "@/hooks/useSettings";
 import { CaptureWrapper } from "@/store/CaptureProvider";
 import { renderItem } from "@/utils/render-item";
@@ -24,7 +25,7 @@ function Index() {
       pagingEnabled: true,
       snapEnabled: true,
       vertical: false,
-      width: 430,
+      width: window.width,
     },
   });
 

--- a/example/app/app/demos/basic-layouts/parallax/demo.tsx
+++ b/example/app/app/demos/basic-layouts/parallax/demo.tsx
@@ -1,3 +1,4 @@
+import { window } from "@/constants/sizes";
 import { renderItem } from "@/utils/render-item";
 import * as React from "react";
 import { View } from "react-native";
@@ -18,9 +19,9 @@ function Index() {
         loop={true}
         pagingEnabled={true}
         snapEnabled={true}
-        width={430}
+        width={window.width}
         style={{
-          width: 430,
+          width: window.width,
         }}
         mode="parallax"
         modeConfig={{

--- a/example/app/app/demos/basic-layouts/parallax/index.tsx
+++ b/example/app/app/demos/basic-layouts/parallax/index.tsx
@@ -28,7 +28,7 @@ function Index() {
       pagingEnabled: true,
       snapEnabled: true,
       vertical: false,
-      width: 430,
+      width: PAGE_WIDTH,
     },
   });
 

--- a/example/app/app/demos/basic-layouts/stack/index.tsx
+++ b/example/app/app/demos/basic-layouts/stack/index.tsx
@@ -5,6 +5,7 @@ import Carousel, { ICarouselInstance } from "react-native-reanimated-carousel";
 import { CustomSelectActionItem } from "@/components/ActionItems";
 import { CarouselAdvancedSettingsPanel } from "@/components/CarouselAdvancedSettingsPanel";
 import { defaultDataWith6Colors } from "@/components/CarouselBasicSettingsPanel";
+import { window } from "@/constants/sizes";
 import { useAdvancedSettings } from "@/hooks/useSettings";
 import { CaptureWrapper } from "@/store/CaptureProvider";
 import { renderItem } from "@/utils/render-item";
@@ -26,7 +27,7 @@ function Index() {
       pagingEnabled: true,
       snapEnabled: true,
       vertical: false,
-      width: 430,
+      width: window.width,
     },
   });
 

--- a/src/components/Carousel.test.tsx
+++ b/src/components/Carousel.test.tsx
@@ -92,18 +92,17 @@ describe("Test the real swipe behavior of Carousel to ensure it's working as exp
   // Helper function to simulate swipe
   const swipeToLeftOnce = (
     options: {
-      itemWidth: number;
-    } = {
-      itemWidth: slideWidth,
-    }
+      itemWidth?: number;
+      velocityX?: number;
+    } = {}
   ) => {
-    const { itemWidth } = options;
+    const { itemWidth = slideWidth, velocityX = -slideWidth } = options;
     fireGestureHandler<PanGesture>(getByGestureTestId(gestureTestId), [
-      { state: State.BEGAN, translationX: 0 },
-      { state: State.ACTIVE, translationX: -itemWidth * 0.25 },
-      { state: State.ACTIVE, translationX: -itemWidth * 0.5 },
-      { state: State.ACTIVE, translationX: -itemWidth * 0.75 },
-      { state: State.END, translationX: -itemWidth },
+      { state: State.BEGAN, translationX: 0, velocityX },
+      { state: State.ACTIVE, translationX: -itemWidth * 0.25, velocityX },
+      { state: State.ACTIVE, translationX: -itemWidth * 0.5, velocityX },
+      { state: State.ACTIVE, translationX: -itemWidth * 0.75, velocityX },
+      { state: State.END, translationX: -itemWidth, velocityX },
     ]);
   };
 
@@ -301,9 +300,9 @@ describe("Test the real swipe behavior of Carousel to ensure it's working as exp
       await verifyInitialRender(getByTestId);
 
       fireGestureHandler<PanGesture>(getByGestureTestId(gestureTestId), [
-        { state: State.BEGAN, translationX: 0 },
-        { state: State.ACTIVE, translationX: -slideWidth * 0.15, velocityX: 0 },
-        { state: State.END, translationX: -slideWidth * 0.25, velocityX: 0 },
+        { state: State.BEGAN, translationX: 0, velocityX: -5 },
+        { state: State.ACTIVE, translationX: -slideWidth * 0.15, velocityX: -5 },
+        { state: State.END, translationX: -slideWidth * 0.25, velocityX: -5 },
       ]);
 
       await waitFor(() => expect(progress.current).toBe(0));
@@ -314,9 +313,9 @@ describe("Test the real swipe behavior of Carousel to ensure it's working as exp
       await verifyInitialRender(getByTestId);
 
       fireGestureHandler<PanGesture>(getByGestureTestId(gestureTestId), [
-        { state: State.BEGAN, translationX: 0 },
-        { state: State.ACTIVE, translationX: -slideWidth * 0.15, velocityX: 0 },
-        { state: State.END, translationX: -slideWidth * 0.25, velocityX: 0 },
+        { state: State.BEGAN, translationX: 0, velocityX: -1000 },
+        { state: State.ACTIVE, translationX: -slideWidth * 0.15, velocityX: -1000 },
+        { state: State.END, translationX: -slideWidth * 0.25, velocityX: -1000 },
       ]);
 
       await waitFor(() => expect(progress.current).toBe(1));
@@ -354,9 +353,9 @@ describe("Test the real swipe behavior of Carousel to ensure it's working as exp
     await verifyInitialRender(getByTestId);
 
     fireGestureHandler<PanGesture>(getByGestureTestId(gestureTestId), [
-      { state: State.BEGAN, translationX: 0 },
-      { state: State.ACTIVE, translationX: slideWidth / 2 },
-      { state: State.END, translationX: slideWidth },
+      { state: State.BEGAN, translationX: 0, velocityX: 1000 },
+      { state: State.ACTIVE, translationX: slideWidth / 2, velocityX: 1000 },
+      { state: State.END, translationX: slideWidth, velocityX: 1000 },
     ]);
 
     await waitFor(() => {
@@ -377,9 +376,9 @@ describe("Test the real swipe behavior of Carousel to ensure it's working as exp
     await verifyInitialRender(getByTestId);
 
     fireGestureHandler<PanGesture>(getByGestureTestId(gestureTestId), [
-      { state: State.BEGAN, translationX: 0 },
-      { state: State.ACTIVE, translationX: slideWidth / 2 },
-      { state: State.END, translationX: slideWidth },
+      { state: State.BEGAN, translationX: 0, velocityX: 1000 },
+      { state: State.ACTIVE, translationX: slideWidth / 2, velocityX: 1000 },
+      { state: State.END, translationX: slideWidth, velocityX: 1000 },
     ]);
 
     await waitFor(() => {
@@ -407,9 +406,9 @@ describe("Test the real swipe behavior of Carousel to ensure it's working as exp
     });
 
     fireGestureHandler<PanGesture>(getByGestureTestId(gestureTestId), [
-      { state: State.BEGAN, translationX: 0 },
-      { state: State.ACTIVE, translationX: -slideWidth / 2 },
-      { state: State.END, translationX: -slideWidth },
+      { state: State.BEGAN, translationX: 0, velocityX: -1000 },
+      { state: State.ACTIVE, translationX: -slideWidth / 2, velocityX: -1000 },
+      { state: State.END, translationX: -slideWidth, velocityX: -1000 },
     ]);
 
     await waitFor(() => {
@@ -419,21 +418,25 @@ describe("Test the real swipe behavior of Carousel to ensure it's working as exp
   });
 
   it("`fixedDirection` prop: should swipe to the correct direction when fixedDirection is positive", async () => {
-    const progress = { current: 0 };
-    const Wrapper = createCarousel(progress);
     {
+      const progress = { current: 0 };
+      const Wrapper = createCarousel(progress);
       const { getByTestId } = render(<Wrapper fixedDirection="positive" />);
       await verifyInitialRender(getByTestId);
 
-      swipeToLeftOnce();
-      await waitFor(() => expect(progress.current).toBe(3));
+      swipeToLeftOnce({ velocityX: slideWidth });
+      await waitFor(() => {
+        expect(progress.current).toBe(3);
+      });
     }
 
     {
+      const progress = { current: 0 };
+      const Wrapper = createCarousel(progress);
       const { getByTestId } = render(<Wrapper fixedDirection="negative" />);
       await verifyInitialRender(getByTestId);
 
-      swipeToLeftOnce();
+      swipeToLeftOnce({ velocityX: -slideWidth });
       await waitFor(() => expect(progress.current).toBe(1));
     }
   });


### PR DESCRIPTION
<!-- Is this PR related to an open issue? -->
<!-- GitHub: Fixes #0, Relates to #1, etc. -->

### Description

<!-- Summary of changes and why if no corresponding issue -->
https://github.com/dohooo/react-native-reanimated-carousel/pull/596

### Review

- [ ] I self-reviewed this PR

<!-- Call out any changes that you'd like people to review or feedback on -->

### Testing

- [ ] I added/updated tests
- [ ] I manually tested

<!-- Describe any manual testing -->
