### PR TITLE
Fix: zIndex crash without rounding (Fixes #748)

### DIFF
--- a/src/layouts/stack.ts
+++ b/src/layouts/stack.ts
@@ -269,13 +269,15 @@ function getCommonStyles(opts: {
 
   if (snapDirection === "left") {
     zIndex =
-      Math.floor(
-        interpolate(
-          value,
-          [-1.5, -1, -1 + Number.MIN_VALUE, 0, validLength],
-          [Number.MIN_VALUE, validLength, validLength, validLength - 1, -1]
-        ) * 10000
-      ) / 100;
+      Math.round(
+        Math.floor(
+          interpolate(
+            value,
+            [-1.5, -1, -1 + Number.MIN_VALUE, 0, validLength],
+            [Number.MIN_VALUE, validLength, validLength, validLength - 1, -1]
+          ) * 10000
+        ) / 100
+      );
 
     opacity = interpolate(
       value,
@@ -284,13 +286,15 @@ function getCommonStyles(opts: {
     );
   } else if (snapDirection === "right") {
     zIndex =
-      Math.floor(
-        interpolate(
-          value,
-          [-validLength, 0, 1 - Number.MIN_VALUE, 1, 1.5],
-          [1, validLength - 1, validLength, validLength, Number.MIN_VALUE]
-        ) * 10000
-      ) / 100;
+      Math.round(
+        Math.floor(
+          interpolate(
+            value,
+            [-validLength, 0, 1 - Number.MIN_VALUE, 1, 1.5],
+            [1, validLength - 1, validLength, validLength, Number.MIN_VALUE]
+          ) * 10000
+        ) / 100
+      );
     opacity = interpolate(
       value,
       [-validLength, 1 - validLength, 0, 1],


### PR DESCRIPTION
# Error zIndex rounding made app crash

### Description

As reported in #748, there was an issue on Android when using the stack layout. Once the user tried to drag the carousel, the app crashed. This is due to a problem in the zIndex calculation of the stack layout, that was not rounded in the end. 

### Review

- [x] I self-reviewed this PR
- [ ] Test it on iOS

### Testing

- [ ] I added/updated tests
- [x] I manually tested


This is my first PR in a project like this, if I can improve anything please tell me 😄 !
