### PR TITLE
fix: #684 type error `property push does not exist on type`

### DIFF
--- a/src/layouts/stack.ts
+++ b/src/layouts/stack.ts
@@ -49,7 +49,6 @@ export function horizontalStackLayout(modeConfig: ILayoutConfig = {}) {
       rotateZDeg = 30,
     } = modeConfig;
 
-    const transform: TransformsStyle["transform"] = [];
     const { validLength, value, inputRange } = getCommonVariables({
       showLength: showLength!,
       value: _value,
@@ -61,12 +60,6 @@ export function horizontalStackLayout(modeConfig: ILayoutConfig = {}) {
       opacityInterval,
       snapDirection,
     });
-
-    const styles: ViewStyle = {
-      transform,
-      zIndex,
-      opacity,
-    };
 
     let translateX: number;
     let scale: number;
@@ -102,7 +95,7 @@ export function horizontalStackLayout(modeConfig: ILayoutConfig = {}) {
       rotateZ = `${interpolate(value, inputRange, [0, 0, rotateZDeg], Extrapolation.CLAMP)}deg`;
     }
 
-    transform.push(
+    const transform: TransformsStyle["transform"] = [
       {
         translateX: translateX!,
       },
@@ -111,8 +104,14 @@ export function horizontalStackLayout(modeConfig: ILayoutConfig = {}) {
       },
       {
         rotateZ: rotateZ!,
-      }
-    );
+      },
+    ];
+
+    const styles: ViewStyle = {
+      transform,
+      zIndex,
+      opacity,
+    };
 
     return styles;
   };
@@ -150,7 +149,7 @@ export function verticalStackLayout(modeConfig: ILayoutConfig = {}) {
       opacityInterval = 0.1,
       rotateZDeg = 30,
     } = modeConfig;
-    const transform: TransformsStyle["transform"] = [];
+
     const { validLength, value, inputRange } = getCommonVariables({
       showLength: showLength!,
       value: _value,
@@ -162,12 +161,6 @@ export function verticalStackLayout(modeConfig: ILayoutConfig = {}) {
       opacityInterval,
       snapDirection,
     });
-
-    const styles: ViewStyle = {
-      transform,
-      zIndex,
-      opacity,
-    };
 
     let translateX: number;
     let scale: number;
@@ -206,7 +199,7 @@ export function verticalStackLayout(modeConfig: ILayoutConfig = {}) {
       );
     }
 
-    transform.push(
+    const transform: TransformsStyle["transform"] = [
       {
         translateX: translateX!,
       },
@@ -218,8 +211,14 @@ export function verticalStackLayout(modeConfig: ILayoutConfig = {}) {
       },
       {
         translateY: translateY!,
-      }
-    );
+      },
+    ];
+
+    const styles: ViewStyle = {
+      transform,
+      zIndex,
+      opacity,
+    };
 
     return styles;
   };


### PR DESCRIPTION
<!-- Is this PR related to an open issue? -->
<!-- GitHub: Fixes #0, Relates to #1, etc. -->

Fixes https://github.com/dohooo/react-native-reanimated-carousel/issues/684

### Description

Applied the patch mentioned in https://github.com/dohooo/react-native-reanimated-carousel/issues/684#issuecomment-2431457629 so that dependent projects can stop relying on patches.

<!-- Summary of changes and why if no corresponding issue -->

### Review

- [x] I self-reviewed this PR

<!-- Call out any changes that you'd like people to review or feedback on -->

### Testing

- [ ] I added/updated tests
- [x] I manually tested

<!-- Describe any manual testing -->
