### PR TITLE
Feat/added a11y props to custom pagination

### DIFF
--- a/src/components/Pagination/Custom/PaginationItem.tsx
+++ b/src/components/Pagination/Custom/PaginationItem.tsx
@@ -15,7 +15,10 @@ import Animated, {
 
 import type { DefaultStyle } from "react-native-reanimated/lib/typescript/reanimated2/hook/commonTypes";
 
-export type DotStyle = Omit<ViewStyle, "width" | "height" | "backgroundColor" | "borderRadius"> & {
+export type DotStyle = Omit<
+  ViewStyle,
+  "width" | "height" | "backgroundColor" | "borderRadius"
+> & {
   width?: number;
   height?: number;
   backgroundColor?: string;
@@ -32,7 +35,12 @@ export const PaginationItem: React.FC<
     dotStyle?: DotStyle;
     activeDotStyle?: DotStyle;
     onPress: () => void;
-    customReanimatedStyle?: (progress: number, index: number, length: number) => DefaultStyle;
+    customReanimatedStyle?: (
+      progress: number,
+      index: number,
+      length: number
+    ) => DefaultStyle;
+    accessibilityLabel?: string;
   }>
 > = (props) => {
   const defaultDotSize = 10;
@@ -47,10 +55,12 @@ export const PaginationItem: React.FC<
     children,
     customReanimatedStyle,
     onPress,
+    accessibilityLabel,
   } = props;
   const customReanimatedStyleRef = useSharedValue<DefaultStyle>({});
   const handleCustomAnimation = (progress: number) => {
-    customReanimatedStyleRef.value = customReanimatedStyle?.(progress, index, count) ?? {};
+    customReanimatedStyleRef.value =
+      customReanimatedStyle?.(progress, index, count) ?? {};
   };
 
   useDerivedValue(() => {
@@ -73,18 +83,33 @@ export const PaginationItem: React.FC<
       ...restActiveDotStyle
     } = activeDotStyle ?? {};
     let val = Math.abs(animValue?.value - index);
-    if (index === 0 && animValue?.value > count - 1) val = Math.abs(animValue?.value - count);
+    if (index === 0 && animValue?.value > count - 1)
+      val = Math.abs(animValue?.value - count);
 
     const inputRange = [0, 1, 2];
     const restStyle = (val === 0 ? restActiveDotStyle : restDotStyle) ?? {};
 
     return {
-      width: interpolate(val, inputRange, [activeWidth, width, width], Extrapolation.CLAMP),
-      height: interpolate(val, inputRange, [activeHeight, height, height], Extrapolation.CLAMP),
+      width: interpolate(
+        val,
+        inputRange,
+        [activeWidth, width, width],
+        Extrapolation.CLAMP
+      ),
+      height: interpolate(
+        val,
+        inputRange,
+        [activeHeight, height, height],
+        Extrapolation.CLAMP
+      ),
       borderRadius: interpolate(
         val,
         inputRange,
-        [activeBorderRadius ?? borderRadius ?? 0, borderRadius ?? 0, borderRadius ?? 0],
+        [
+          activeBorderRadius ?? borderRadius ?? 0,
+          borderRadius ?? 0,
+          borderRadius ?? 0,
+        ],
         Extrapolation.CLAMP
       ),
       backgroundColor: interpolateColor(val, inputRange, [
@@ -99,10 +124,26 @@ export const PaginationItem: React.FC<
         ...(customReanimatedStyleRef.value?.transform ?? []),
       ] as DefaultStyle["transform"],
     };
-  }, [animValue, index, count, horizontal, dotStyle, activeDotStyle, customReanimatedStyle]);
+  }, [
+    animValue,
+    index,
+    count,
+    horizontal,
+    dotStyle,
+    activeDotStyle,
+    customReanimatedStyle,
+  ]);
 
   return (
-    <TouchableWithoutFeedback onPress={onPress}>
+    <TouchableWithoutFeedback
+      onPress={onPress}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      accessibilityHint={
+        animValue.value === index ? "" : `Go to ${accessibilityLabel}`
+      }
+      accessibilityState={{ selected: animValue.value === index }}
+    >
       <Animated.View
         style={[
           {

--- a/src/components/Pagination/Custom/index.tsx
+++ b/src/components/Pagination/Custom/index.tsx
@@ -19,6 +19,7 @@ export interface ShapeProps<T extends {}> {
   size?: number;
   onPress?: (index: number) => void;
   customReanimatedStyle?: (progress: number, index: number, length: number) => DefaultStyle;
+  carouselName?: string;
 }
 
 export const Custom = <T extends {}>(props: ShapeProps<T>) => {
@@ -33,6 +34,7 @@ export const Custom = <T extends {}>(props: ShapeProps<T>) => {
     renderItem,
     onPress,
     customReanimatedStyle,
+    carouselName,
   } = props;
 
   if (
@@ -79,6 +81,7 @@ export const Custom = <T extends {}>(props: ShapeProps<T>) => {
             activeDotStyle={activeDotStyle}
             customReanimatedStyle={customReanimatedStyle}
             onPress={() => onPress?.(index)}
+            accessibilityLabel={`Slide ${index + 1} of ${data.length} - ${carouselName}`}
           >
             {renderItem?.(item, index)}
           </PaginationItem>


### PR DESCRIPTION
<!-- Is this PR related to an open issue? -->
<!-- GitHub: Fixes #0, Relates to #1, etc. -->

### Description

- Added accessibility props to custom pagination to allow for appropriate labelling for screen readers

### Review

- [x] I self-reviewed this PR

<!-- Call out any changes that you'd like people to review or feedback on -->

### Testing

- [ ] I added/updated tests
- [x] I manually tested

<!-- Describe any manual testing -->

- Used xcode's Accessibility Inspector to ensure that pagination dots can now be focused and contain the correct labelling, includes hints and states
