### PR TITLE
fix: replace TouchableWithoutFeedback with Pressable in pagination

### DIFF
--- a/.changeset/fix-touchable-deprecation.md
+++ b/.changeset/fix-touchable-deprecation.md
@@ -1,0 +1,9 @@
+---
+"react-native-reanimated-carousel": patch
+---
+
+Replace deprecated TouchableWithoutFeedback with Pressable in pagination components
+
+Fixes deprecation warnings by replacing TouchableWithoutFeedback with the recommended Pressable component in both Basic and Custom pagination items. This change maintains the same functionality while using the modern React Native API.
+
+Closes #812

--- a/src/components/Pagination/Basic/PaginationItem.tsx
+++ b/src/components/Pagination/Basic/PaginationItem.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from "react";
 import React from "react";
 import type { ViewStyle } from "react-native";
-import { TouchableWithoutFeedback, View } from "react-native";
+import { Pressable, View } from "react-native";
 import Animated, { Extrapolation, interpolate, useAnimatedStyle } from "react-native-reanimated";
 
 export type DotStyle = Omit<ViewStyle, "width" | "height"> & {
@@ -63,7 +63,7 @@ export const PaginationItem: React.FC<
   }, [animValue, index, count, horizontal]);
 
   return (
-    <TouchableWithoutFeedback onPress={onPress}>
+    <Pressable onPress={onPress}>
       <View
         style={[
           {
@@ -92,6 +92,6 @@ export const PaginationItem: React.FC<
           {children}
         </Animated.View>
       </View>
-    </TouchableWithoutFeedback>
+    </Pressable>
   );
 };

--- a/src/components/Pagination/Custom/PaginationItem.tsx
+++ b/src/components/Pagination/Custom/PaginationItem.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from "react";
 import React from "react";
-import { TouchableWithoutFeedback } from "react-native";
+import { Pressable } from "react-native";
 import type { ViewStyle } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
 import Animated, {
@@ -102,7 +102,7 @@ export const PaginationItem: React.FC<
   }, [animValue, index, count, horizontal, dotStyle, activeDotStyle, customReanimatedStyle]);
 
   return (
-    <TouchableWithoutFeedback onPress={onPress}>
+    <Pressable onPress={onPress}>
       <Animated.View
         style={[
           {
@@ -119,6 +119,6 @@ export const PaginationItem: React.FC<
       >
         {children}
       </Animated.View>
-    </TouchableWithoutFeedback>
+    </Pressable>
   );
 };


### PR DESCRIPTION
<!-- GitHub: Fixes #812 -->

### Description

Replaces deprecated `TouchableWithoutFeedback` with `Pressable` in pagination components to remove deprecation warnings while maintaining the same functionality.

**Changes:**
- Updated Basic PaginationItem to use `Pressable` instead of `TouchableWithoutFeedback`
- Updated Custom PaginationItem to use `Pressable` instead of `TouchableWithoutFeedback`
- Added changeset for patch version bump

### Review

- [x] I self-reviewed this PR

The changes are straightforward replacements that maintain exact functionality while using the modern React Native API.

### Testing

- [x] I manually tested
- [x] Existing tests still pass

**Manual testing performed:**
- Verified pagination dots remain clickable
- Confirmed no visual changes to pagination behavior
- Checked that deprecation warnings are eliminated
- Tested on both Basic and Custom pagination components

Closes #812