### PR TITLE
feat: add accessibility support to pagination components

### DIFF
--- a/.changeset/add-pagination-accessibility.md
+++ b/.changeset/add-pagination-accessibility.md
@@ -1,0 +1,12 @@
+---
+"react-native-reanimated-carousel": patch
+---
+
+Add accessibility support to pagination components and replace deprecated TouchableWithoutFeedback with Pressable
+
+- Add comprehensive accessibility props (accessibilityLabel, accessibilityRole, accessibilityHint, accessibilityState) to both Basic and Custom pagination components
+- Add carouselName prop to allow descriptive accessibility labels
+- Replace TouchableWithoutFeedback with Pressable to remove deprecation warnings
+- Improve screen reader support with proper labeling and state information
+
+Co-authored-by: AlexJackson01 <alex@example.com>

--- a/src/components/Pagination/Basic/PaginationItem.tsx
+++ b/src/components/Pagination/Basic/PaginationItem.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from "react";
 import React from "react";
 import type { ViewStyle } from "react-native";
-import { TouchableWithoutFeedback, View } from "react-native";
+import { Pressable, View } from "react-native";
 import Animated, { Extrapolation, interpolate, useAnimatedStyle } from "react-native-reanimated";
 
 export type DotStyle = Omit<ViewStyle, "width" | "height"> & {
@@ -19,10 +19,21 @@ export const PaginationItem: React.FC<
     dotStyle?: DotStyle;
     activeDotStyle?: DotStyle;
     onPress: () => void;
+    accessibilityLabel?: string;
   }>
 > = (props) => {
-  const { animValue, dotStyle, activeDotStyle, index, count, size, horizontal, children, onPress } =
-    props;
+  const {
+    animValue,
+    dotStyle,
+    activeDotStyle,
+    index,
+    count,
+    size,
+    horizontal,
+    children,
+    onPress,
+    accessibilityLabel,
+  } = props;
 
   const defaultDotSize = 10;
 
@@ -63,7 +74,13 @@ export const PaginationItem: React.FC<
   }, [animValue, index, count, horizontal]);
 
   return (
-    <TouchableWithoutFeedback onPress={onPress}>
+    <Pressable
+      onPress={onPress}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      accessibilityHint={animValue.value === index ? "" : `Go to ${accessibilityLabel}`}
+      accessibilityState={{ selected: animValue.value === index }}
+    >
       <View
         style={[
           {
@@ -92,6 +109,6 @@ export const PaginationItem: React.FC<
           {children}
         </Animated.View>
       </View>
-    </TouchableWithoutFeedback>
+    </Pressable>
   );
 };

--- a/src/components/Pagination/Basic/index.tsx
+++ b/src/components/Pagination/Basic/index.tsx
@@ -15,6 +15,7 @@ export interface BasicProps<T> {
   activeDotStyle?: DotStyle;
   size?: number;
   onPress?: (index: number) => void;
+  carouselName?: string;
 }
 
 export const Basic = <T extends {}>(props: BasicProps<T>) => {
@@ -28,6 +29,7 @@ export const Basic = <T extends {}>(props: BasicProps<T>) => {
     containerStyle,
     renderItem,
     onPress,
+    carouselName,
   } = props;
 
   if (
@@ -66,6 +68,7 @@ export const Basic = <T extends {}>(props: BasicProps<T>) => {
             horizontal={!horizontal}
             activeDotStyle={activeDotStyle}
             onPress={() => onPress?.(index)}
+            accessibilityLabel={`Slide ${index + 1} of ${data.length} - ${carouselName}`}
           >
             {renderItem?.(item, index)}
           </PaginationItem>

--- a/src/components/Pagination/Custom/PaginationItem.tsx
+++ b/src/components/Pagination/Custom/PaginationItem.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from "react";
 import React from "react";
-import { TouchableWithoutFeedback } from "react-native";
+import { Pressable } from "react-native";
 import type { ViewStyle } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
 import Animated, {
@@ -33,6 +33,7 @@ export const PaginationItem: React.FC<
     activeDotStyle?: DotStyle;
     onPress: () => void;
     customReanimatedStyle?: (progress: number, index: number, length: number) => DefaultStyle;
+    accessibilityLabel?: string;
   }>
 > = (props) => {
   const defaultDotSize = 10;
@@ -47,6 +48,7 @@ export const PaginationItem: React.FC<
     children,
     customReanimatedStyle,
     onPress,
+    accessibilityLabel,
   } = props;
   const customReanimatedStyleRef = useSharedValue<DefaultStyle>({});
   const handleCustomAnimation = (progress: number) => {
@@ -102,7 +104,13 @@ export const PaginationItem: React.FC<
   }, [animValue, index, count, horizontal, dotStyle, activeDotStyle, customReanimatedStyle]);
 
   return (
-    <TouchableWithoutFeedback onPress={onPress}>
+    <Pressable
+      onPress={onPress}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      accessibilityHint={animValue.value === index ? "" : `Go to ${accessibilityLabel}`}
+      accessibilityState={{ selected: animValue.value === index }}
+    >
       <Animated.View
         style={[
           {
@@ -119,6 +127,6 @@ export const PaginationItem: React.FC<
       >
         {children}
       </Animated.View>
-    </TouchableWithoutFeedback>
+    </Pressable>
   );
 };

--- a/src/components/Pagination/Custom/index.tsx
+++ b/src/components/Pagination/Custom/index.tsx
@@ -19,6 +19,7 @@ export interface ShapeProps<T extends {}> {
   size?: number;
   onPress?: (index: number) => void;
   customReanimatedStyle?: (progress: number, index: number, length: number) => DefaultStyle;
+  carouselName?: string;
 }
 
 export const Custom = <T extends {}>(props: ShapeProps<T>) => {
@@ -33,6 +34,7 @@ export const Custom = <T extends {}>(props: ShapeProps<T>) => {
     renderItem,
     onPress,
     customReanimatedStyle,
+    carouselName,
   } = props;
 
   if (
@@ -79,6 +81,7 @@ export const Custom = <T extends {}>(props: ShapeProps<T>) => {
             activeDotStyle={activeDotStyle}
             customReanimatedStyle={customReanimatedStyle}
             onPress={() => onPress?.(index)}
+            accessibilityLabel={`Slide ${index + 1} of ${data.length} - ${carouselName}`}
           >
             {renderItem?.(item, index)}
           </PaginationItem>


### PR DESCRIPTION
## 📝 Description

This PR adds comprehensive accessibility support to pagination components and replaces deprecated `TouchableWithoutFeedback` with `Pressable`.

## ✨ Features

- **Enhanced Accessibility**: Added comprehensive accessibility props (`accessibilityLabel`, `accessibilityRole`, `accessibilityHint`, `accessibilityState`) to both Basic and Custom pagination components
- **Descriptive Labels**: Added `carouselName` prop to allow more descriptive accessibility labels
- **Deprecation Fix**: Replaced deprecated `TouchableWithoutFeedback` with `Pressable` to remove warnings
- **Screen Reader Support**: Improved screen reader experience with proper labeling and state information

## 🔧 Technical Changes

### Files Modified:
- `src/components/Pagination/Basic/PaginationItem.tsx`
- `src/components/Pagination/Custom/PaginationItem.tsx`  
- `src/components/Pagination/Basic/index.tsx`
- `src/components/Pagination/Custom/index.tsx`

### Key Improvements:
1. **TouchableWithoutFeedback → Pressable**: Removes React Native deprecation warnings
2. **Accessibility Props**: Each pagination item now includes:
   - `accessibilityLabel`: Descriptive label like "Slide 1 of 5 - Photo Gallery"
   - `accessibilityRole`: Set to "button" for proper semantic meaning
   - `accessibilityHint`: Provides action guidance for unselected items
   - `accessibilityState`: Indicates selected/unselected state
3. **CarouselName Prop**: Allows developers to provide contextual names for better accessibility

## 🙏 Credits

This work builds upon the excellent accessibility enhancements started by @AlexJackson01 in #825. Thank you for the great foundation!

## ✅ Testing

- [x] Tested with VoiceOver on iOS
- [x] Tested with TalkBack on Android  
- [x] No breaking changes to existing API
- [x] Maintains backward compatibility

Co-authored-by: AlexJackson01 <alex@example.com>