### PR TITLE
Fix non-loop overscroll after left edge (credit PR 839)

### DIFF
--- a/.changeset/fix-nonloop-overscroll.md
+++ b/.changeset/fix-nonloop-overscroll.md
@@ -1,0 +1,5 @@
+---
+"react-native-reanimated-carousel": patch
+---
+
+Fix non-loop overscroll direction so tiny positive offsets at the first page no longer wrap to the last page when calling next()/scrollTo(), and add integration coverage for the scenario. Thanks to @hennessyevan for the original report and PR 839 inspiration.


### PR DESCRIPTION
<!-- Is this PR related to an open issue? -->
Related to PR #839 (overscroll edge case when loop=false)

### Description
- Fix non-loop page calculation to clamp tiny positive offsets at the first page (no wrap to last page)
- Preserve fixedDirection semantics while choosing direction in non-loop mode; avoid forced -1
- Add integration test for first-page left overscroll then next()/scrollTo()
- Add changeset with credit to @hennessyevan / PR 839

### Review
- [x] I self-reviewed this PR

### Testing
- [x] I added/updated tests
- [ ] I manually tested

Automated: yarn test