### PR TITLE
fix: upgrade react-native-worklets to 0.5.2 to fix web crash

### DIFF
--- a/.changeset/fix-web-worklets-error.md
+++ b/.changeset/fix-web-worklets-error.md
@@ -1,0 +1,5 @@
+---
+"react-native-reanimated-carousel": patch
+---
+
+Fix web documentation examples crash by upgrading react-native-worklets from 0.5.1 to 0.5.2. This resolves the "createSerializableObject should never be called in JSWorklets" error that occurred on web platform.

--- a/example/app/package.json
+++ b/example/app/package.json
@@ -49,7 +49,7 @@
 		"react-native-svg": "15.12.1",
 		"react-native-view-shot": "~4.0.3",
 		"react-native-web": "^0.21.0",
-		"react-native-worklets": "0.5.1",
+		"react-native-worklets": "0.5.2",
 		"tamagui": "1.133.1"
 	},
 	"devDependencies": {
@@ -72,6 +72,6 @@
 		"react-native": "0.81.4",
 		"react-native-gesture-handler": "2.28.0",
 		"react-native-reanimated": "4.1.0",
-		"react-native-worklets": "0.5.1"
+		"react-native-worklets": "0.5.2"
 	}
 }

--- a/example/app/yarn.lock
+++ b/example/app/yarn.lock
@@ -6438,7 +6438,7 @@ __metadata:
     react-native-svg-transformer: "npm:^1.5.0"
     react-native-view-shot: "npm:~4.0.3"
     react-native-web: "npm:^0.21.0"
-    react-native-worklets: "npm:0.5.1"
+    react-native-worklets: "npm:0.5.2"
     react-test-renderer: "npm:19.1.0"
     tamagui: "npm:1.133.1"
     typescript: "npm:~5.9.2"
@@ -12533,9 +12533,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-worklets@npm:0.5.1":
-  version: 0.5.1
-  resolution: "react-native-worklets@npm:0.5.1"
+"react-native-worklets@npm:0.5.2":
+  version: 0.5.2
+  resolution: "react-native-worklets@npm:0.5.2"
   dependencies:
     "@babel/plugin-transform-arrow-functions": "npm:^7.0.0-0"
     "@babel/plugin-transform-class-properties": "npm:^7.0.0-0"
@@ -12552,7 +12552,7 @@ __metadata:
     "@babel/core": ^7.0.0-0
     react: "*"
     react-native: "*"
-  checksum: 39e70b64560cc4b031ac329bfbd0686b744b6940bbe1d1768a227bb9e142a0e2bad5ef16752003e83374db49d8d6396c72236b9c279e1465a7177f887ae12d48
+  checksum: 97fefdf31e84428bf90cb425aaf814b1b6e450f309a3bc6f85c2bc7107d86e82da9729d21a5fd274632854beed4dcf708d12d88da384d37277901dde7c19f688
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
 		"react-native-gesture-handler": "~2.28.0",
 		"react-native-reanimated": "^4.1.0",
 		"react-native-web": "~0.19.10",
-		"react-native-worklets": "0.5.1",
+		"react-native-worklets": "0.5.2",
 		"react-test-renderer": "19.1.0",
 		"sponsorkit": "^0.1.3",
 		"typescript": "^5.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11413,7 +11413,7 @@ __metadata:
     react-native-gesture-handler: "npm:~2.28.0"
     react-native-reanimated: "npm:^4.1.0"
     react-native-web: "npm:~0.19.10"
-    react-native-worklets: "npm:0.5.1"
+    react-native-worklets: "npm:0.5.2"
     react-test-renderer: "npm:19.1.0"
     sponsorkit: "npm:^0.1.3"
     typescript: "npm:^5.5.4"
@@ -11461,9 +11461,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-worklets@npm:0.5.1":
-  version: 0.5.1
-  resolution: "react-native-worklets@npm:0.5.1"
+"react-native-worklets@npm:0.5.2":
+  version: 0.5.2
+  resolution: "react-native-worklets@npm:0.5.2"
   dependencies:
     "@babel/plugin-transform-arrow-functions": "npm:^7.0.0-0"
     "@babel/plugin-transform-class-properties": "npm:^7.0.0-0"
@@ -11480,7 +11480,7 @@ __metadata:
     "@babel/core": ^7.0.0-0
     react: "*"
     react-native: "*"
-  checksum: 39e70b64560cc4b031ac329bfbd0686b744b6940bbe1d1768a227bb9e142a0e2bad5ef16752003e83374db49d8d6396c72236b9c279e1465a7177f887ae12d48
+  checksum: 97fefdf31e84428bf90cb425aaf814b1b6e450f309a3bc6f85c2bc7107d86e82da9729d21a5fd274632854beed4dcf708d12d88da384d37277901dde7c19f688
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Upgrades `react-native-worklets` from 0.5.1 to 0.5.2
- Fixes the web documentation examples crash that caused all live examples on rn-carousel.dev to show "Loading..." indefinitely

## Problem

The web examples were crashing with the error:
```
WorkletsError: [Worklets] createSerializableObject should never be called in JSWorklets.
```

This was caused by a bug in `react-native-worklets` 0.5.1 where `globalThis.__RUNTIME_KIND` was accessed before initialization in lazy import environments (like web).

## Solution

Upgrade to `react-native-worklets` 0.5.2 which contains the fix from [software-mansion/react-native-reanimated#8300](https://github.com/software-mansion/react-native-reanimated/pull/8300).

## Test plan

- [x] Verified locally that the web examples now load correctly without errors
- [x] Started the example app with `yarn web` and confirmed the carousel works

Fixes #864