### PR TITLE
Fix 'Carousel' cannot be used as a JSX component with React 19

### DIFF
--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { JSX } from "react";
 import { useCommonVariables } from "../hooks/useCommonVariables";
 import { useInitProps } from "../hooks/useInitProps";
 import { usePropsErrorBoundary } from "../hooks/usePropsErrorBoundary";


### PR DESCRIPTION
<!-- Is this PR related to an open issue? -->
<!-- GitHub: Fixes #0, Relates to #1, etc. -->

### Description

Fix for:
https://github.com/dohooo/react-native-reanimated-carousel/issues/848

With React Native 79+, using React 19, JSX type is not imported by default causing as described in the issue.

### Review

- [x] I self-reviewed this PR


### Testing

- [ ] I added/updated tests
- [x] I manually tested

Local patch fixed my issue:
<img width="837" height="182" alt="Screenshot 2026-01-06 at 17 52 59" src="https://github.com/user-attachments/assets/f12af9a5-67c8-4a02-be51-e289ed0eb03f" />

