### PR TITLE
fix(web): avoid React 19 element.ref warning in gesture path

### DIFF
--- a/src/components/ScrollViewGesture.test.tsx
+++ b/src/components/ScrollViewGesture.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { View } from "react-native";
+
+import { render } from "@testing-library/react-native";
+
+import { ScrollViewGesture } from "./ScrollViewGesture";
+
+import { GlobalStateContext } from "../store";
+
+jest.mock("../hooks/usePanGestureProxy", () => ({
+  usePanGestureProxy: jest.fn(() => ({})),
+}));
+
+jest.mock("react-native-gesture-handler", () => {
+  const React = require("react");
+  const actual = jest.requireActual("react-native-gesture-handler");
+
+  return {
+    ...actual,
+    GestureDetector: ({ children }: { children: React.ReactNode }) => {
+      const child = React.Children.only(children);
+      // Simulate upstream web behavior that reads `element.ref`.
+      // If the child element carries a ref, React 19 emits the warning.
+      // @ts-expect-error React 19 removed `element.ref` from the element type.
+      void child.ref;
+      return child;
+    },
+  };
+});
+
+describe("ScrollViewGesture", () => {
+  it("does not emit React 19 `element.ref` warning", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const contextValue = {
+      props: {
+        onConfigurePanGesture: undefined,
+        vertical: false,
+        pagingEnabled: true,
+        snapEnabled: true,
+        loop: false,
+        scrollAnimationDuration: 500,
+        withAnimation: undefined,
+        enabled: true,
+        dataLength: 3,
+        overscrollEnabled: false,
+        maxScrollDistancePerSwipe: undefined,
+        minScrollDistancePerSwipe: undefined,
+        fixedDirection: undefined,
+      },
+      common: {
+        size: 300,
+        validLength: 2,
+        handlerOffset: { value: 0 },
+        resolvedSize: { value: 300 },
+        sizePhase: { value: "ready" },
+        sizeExplicit: true,
+      },
+      layout: {
+        containerSize: { value: { width: 300, height: 200 } },
+        updateContainerSize: jest.fn(),
+        itemDimensions: { value: {} },
+        updateItemDimensions: jest.fn(),
+      },
+    };
+
+    render(
+      <GlobalStateContext.Provider value={contextValue as any}>
+        <ScrollViewGesture
+          size={300}
+          translation={{ value: 0 } as any}
+          style={{ width: 300, height: 200 }}
+        >
+          <View testID="content" />
+        </ScrollViewGesture>
+      </GlobalStateContext.Provider>
+    );
+
+    const react19RefWarnings = errorSpy.mock.calls.filter(([message]) =>
+      String(message).includes("Accessing element.ref was removed in React 19")
+    );
+
+    expect(react19RefWarnings).toHaveLength(0);
+    errorSpy.mockRestore();
+  });
+});

--- a/src/components/ScrollViewGesture.tsx
+++ b/src/components/ScrollViewGesture.tsx
@@ -8,9 +8,7 @@ import type {
 import { GestureDetector } from "react-native-gesture-handler";
 import Animated, {
   cancelAnimation,
-  measure,
   useAnimatedReaction,
-  useAnimatedRef,
   useDerivedValue,
   useSharedValue,
   withDecay,
@@ -56,7 +54,7 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
       fixedDirection,
     },
     common: { size, resolvedSize, sizePhase, sizeExplicit },
-    layout: { updateContainerSize },
+    layout: { containerSize, updateContainerSize },
   } = useGlobalState();
 
   const {
@@ -77,7 +75,6 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
   const validStart = useSharedValue(false);
   const scrollEndTranslation = useSharedValue(0);
   const scrollEndVelocity = useSharedValue(0);
-  const containerRef = useAnimatedRef<Animated.View>();
   const maxScrollDistancePerSwipeIsSet = typeof maxScrollDistancePerSwipe === "number";
   const minScrollDistancePerSwipeIsSet = typeof minScrollDistancePerSwipe === "number";
   const sizeReady = useDerivedValue(() => {
@@ -92,18 +89,19 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
     if (size <= 0) return 0;
 
     if (!loop && !overscrollEnabled) {
-      const measurement = measure(containerRef);
-      const containerWidth = measurement?.width || 0;
+      const containerMainAxisSize = vertical
+        ? containerSize.value.height
+        : containerSize.value.width;
 
-      // If the item's total width is less than the container's width, then there is no need to scroll.
-      if (dataLength * size < containerWidth) return 0;
+      // If the item's total size is less than the container's size, then there is no need to scroll.
+      if (containerMainAxisSize <= 0 || dataLength * size < containerMainAxisSize) return 0;
 
       // Disable the "overscroll" effect
-      return dataLength * size - containerWidth;
+      return dataLength * size - containerMainAxisSize;
     }
 
     return dataLength * size;
-  }, [loop, size, dataLength, overscrollEnabled]);
+  }, [loop, size, dataLength, overscrollEnabled, vertical, containerSize]);
 
   const withSpring = React.useCallback(
     (toValue: number, onFinished?: () => void) => {
@@ -515,7 +513,6 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
   return (
     <GestureDetector gesture={gesture}>
       <Animated.View
-        ref={containerRef}
         testID={testID}
         style={style}
         onTouchStart={onTouchBegin}


### PR DESCRIPTION
## Summary
- remove the `ref` attachment from `ScrollViewGesture`'s `GestureDetector` child to avoid triggering React 19 `element.ref` access warnings on web paths
- replace `measure(containerRef)` boundary calculation with `layout.containerSize` from store (already updated by `onLayout`)
- add a regression test that fails when `Accessing element.ref was removed in React 19` is emitted

## Why
Issue #857 reports React 19 web warning:
`Accessing element.ref was removed in React 19`

The upstream warning is triggered when a dependency reads `element.ref`; passing a child `ref` through this path made the warning visible in carousel usage.

## Tests
- `yarn test src/components/ScrollViewGesture.test.tsx --runInBand`
- `yarn test src/components/Carousel.test.tsx --runInBand`
- `yarn biome check src/components/ScrollViewGesture.tsx src/components/ScrollViewGesture.test.tsx`

Fixes #857