### PR TITLE
fix: avoid render-phase shared value read in getCurrentIndex (fix #829)

### DIFF
--- a/src/components/Carousel.test.tsx
+++ b/src/components/Carousel.test.tsx
@@ -11,7 +11,7 @@ import { fireGestureHandler, getByGestureTestId } from "react-native-gesture-han
 
 import Carousel from "./Carousel";
 
-import type { TCarouselProps } from "../types";
+import type { ICarouselInstance, TCarouselProps } from "../types";
 
 // Suppress the "measure() cannot be used with Jest" warning from Reanimated.
 // The measure export is non-configurable so it cannot be spied on or mocked
@@ -37,6 +37,27 @@ jest.setTimeout(1000 * 12);
 const mockPan = jest.fn();
 const realPan = Gesture.Pan();
 const gestureTestId = "rnrc-gesture-handler";
+const REANIMATED_RENDER_READ_WARNING = "Reading from `value` during component render";
+
+const captureReanimatedRenderReadWarnings = (warnings: string[]) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const cfg = (global as any).__reanimatedLoggerConfig as
+    | { logFunction: (data: { level: number; message: string }) => void }
+    | undefined;
+  if (!cfg) return () => {};
+
+  const originalLog = cfg.logFunction;
+  cfg.logFunction = (data) => {
+    if (data.message.includes(REANIMATED_RENDER_READ_WARNING)) {
+      warnings.push(data.message);
+    }
+    originalLog(data);
+  };
+
+  return () => {
+    cfg.logFunction = originalLog;
+  };
+};
 
 jest.spyOn(Gesture, "Pan").mockImplementation(() => {
   mockPan();
@@ -1059,5 +1080,53 @@ describe("Test the real swipe behavior of Carousel to ensure it's working as exp
       expect(getByTestId("carousel-item-1")).toBeTruthy();
       expect(getByTestId("carousel-item-2")).toBeTruthy();
     });
+  });
+
+  it("should not emit render-time shared-value warning when reading current index during rerender", async () => {
+    const warnings: string[] = [];
+    const restoreLogger = captureReanimatedRenderReadWarnings(warnings);
+    const observedIndex = { current: -1 };
+
+    const RenderReadIndexProbe = () => {
+      const [tick, setTick] = React.useState(0);
+      const carouselRef = React.useRef<ICarouselInstance>(null);
+
+      if (tick > 0) {
+        observedIndex.current = carouselRef.current?.getCurrentIndex() ?? -1;
+      }
+
+      React.useEffect(() => {
+        setTick(1);
+      }, []);
+
+      return (
+        <Carousel
+          ref={carouselRef}
+          data={createMockData()}
+          style={{ width: slideWidth, height: slideHeight }}
+          renderItem={({ item, index }) => (
+            <Animated.View
+              testID={`carousel-item-${index}`}
+              style={{ width: slideWidth, height: slideHeight, flex: 1 }}
+            >
+              {item}
+            </Animated.View>
+          )}
+        />
+      );
+    };
+
+    try {
+      const { getByTestId } = render(<RenderReadIndexProbe />);
+      await verifyInitialRender(getByTestId);
+
+      await waitFor(() => {
+        expect(observedIndex.current).toBe(0);
+      });
+
+      expect(warnings).toEqual([]);
+    } finally {
+      restoreLogger();
+    }
   });
 });

--- a/src/hooks/useCarouselController.tsx
+++ b/src/hooks/useCarouselController.tsx
@@ -96,6 +96,20 @@ export function useCarouselController(options: IOpts): ICarouselController {
     sharedIndex.current = newSharedIndex;
   }
 
+  const syncSharedIndex = React.useCallback(
+    (nextRawIndex: number) => {
+      const nextSharedIndex = convertToSharedIndex({
+        loop,
+        rawDataLength: dataInfo.originalLength,
+        autoFillData: autoFillData!,
+        index: nextRawIndex,
+      });
+
+      setSharedIndex(nextSharedIndex);
+    },
+    [autoFillData, dataInfo, loop]
+  );
+
   useAnimatedReaction(
     () => {
       if (size <= 0) {
@@ -131,14 +145,14 @@ export function useCarouselController(options: IOpts): ICarouselController {
 
   const getCurrentIndex = React.useCallback(() => {
     const realIndex = computedRealIndexWithAutoFillData({
-      index: index.value,
+      index: sharedIndex.current,
       dataLength: dataInfo.originalLength,
       loop,
       autoFillData: autoFillData!,
     });
 
     return realIndex;
-  }, [index, autoFillData, dataInfo, loop]);
+  }, [autoFillData, dataInfo, loop]);
 
   const canSliding = React.useCallback(() => {
     const currentSize = resolvedSize.value ?? size;
@@ -285,6 +299,7 @@ export function useCarouselController(options: IOpts): ICarouselController {
 
       const nextPage = currentFixedPage() + count;
       index.value = nextPage;
+      syncSharedIndex(nextPage);
 
       if (animated) {
         handlerOffset.value = scrollWithTiming(-nextPage * size, onFinished) as any;
@@ -309,6 +324,7 @@ export function useCarouselController(options: IOpts): ICarouselController {
       flattenedStyle,
       width,
       height,
+      syncSharedIndex,
     ]
   );
 
@@ -323,6 +339,7 @@ export function useCarouselController(options: IOpts): ICarouselController {
 
       const prevPage = currentFixedPage() - count;
       index.value = prevPage;
+      syncSharedIndex(prevPage);
 
       if (animated) {
         handlerOffset.value = scrollWithTiming(-prevPage * size, onFinished);
@@ -340,6 +357,7 @@ export function useCarouselController(options: IOpts): ICarouselController {
       size,
       scrollWithTiming,
       currentFixedPage,
+      syncSharedIndex,
     ]
   );
 
@@ -382,10 +400,12 @@ export function useCarouselController(options: IOpts): ICarouselController {
 
       if (animated) {
         index.value = i;
+        syncSharedIndex(i);
         handlerOffset.value = scrollWithTiming(finalOffset, onFinished);
       } else {
         handlerOffset.value = finalOffset;
         index.value = i;
+        syncSharedIndex(i);
         onFinished?.();
       }
     },
@@ -399,6 +419,7 @@ export function useCarouselController(options: IOpts): ICarouselController {
       canSliding,
       onScrollStart,
       scrollWithTiming,
+      syncSharedIndex,
     ]
   );
 


### PR DESCRIPTION
## Summary
This PR fixes the render-phase shared value warning reported in #829:

> Reading from `value` during component render...

The warning was triggered when `getCurrentIndex()` was called during React render (for example through an imperative `ref` read during rerender).

## 1) Trigger chain
- `Carousel` exposes imperative `getCurrentIndex()` from `useCarouselController`.
- Before this fix, `getCurrentIndex()` read `index.value` directly.
- If user code calls `ref.current?.getCurrentIndex()` during component render, Reanimated strict logger reports render-phase shared value access.

## 2) Fix strategy
- Keep a JS-side index snapshot (`sharedIndex.current`) as the source for imperative reads.
- Change `getCurrentIndex()` to read `sharedIndex.current` instead of `index.value`.
- Add `syncSharedIndex()` and update it in `next/prev/to` paths so imperative commands remain consistent immediately.
- Keep animation/gesture logic unchanged (no warning silencing, no logger suppression).

## 3) Regression test
Added a warning-level regression test in `src/components/Carousel.test.tsx`:
- Captures Reanimated logger output for `Reading from `value` during component render`.
- Reproduces minimal scenario: rerender + imperative `getCurrentIndex()` read during render.
- Asserts no warning is emitted after the fix.

This test is Red before the fix and Green after.

## 4) Validation
Executed:

```bash
yarn test src/components/Carousel.test.tsx src/hooks/useCarouselController.test.tsx src/components/Pagination/Pagination.test.tsx --runInBand --verbose=false
```

Result:
- 3 test suites passed
- 80 tests passed

## Notes
- This does not mute or disable Reanimated strict warnings.
- Existing interaction behavior remains covered by controller and carousel tests.

Closes #829.