### PR TITLE
test(example): add issue #862 Expo 54/RN 0.81 regression coverage

### DIFF
--- a/example/app/__tests__/issue-862.carousel-items.test.tsx
+++ b/example/app/__tests__/issue-862.carousel-items.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text } from "react-native";
-import renderer, { act } from "react-test-renderer";
 import Carousel from "react-native-reanimated-carousel";
+import renderer, { act } from "react-test-renderer";
 
 describe("issue #862", () => {
   it("renders carousel items in the Expo SDK 54 / RN 0.81 Jest environment", () => {
@@ -21,11 +21,8 @@ describe("issue #862", () => {
     });
 
     expect(tree!.root.findAllByProps({ testID: "issue-862-item-0" }).length).toBeGreaterThan(0);
-    expect(
-      tree!
-        .root
-        .findAllByType(Text)
-        .some((node) => node.props.children === "Slide 0")
-    ).toBe(true);
+    expect(tree!.root.findAllByType(Text).some((node) => node.props.children === "Slide 0")).toBe(
+      true
+    );
   });
 });

--- a/example/app/__tests__/issue-862.carousel-items.test.tsx
+++ b/example/app/__tests__/issue-862.carousel-items.test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Text } from "react-native";
+import renderer, { act } from "react-test-renderer";
+import Carousel from "react-native-reanimated-carousel";
+
+describe("issue #862", () => {
+  it("renders carousel items in the Expo SDK 54 / RN 0.81 Jest environment", () => {
+    let tree: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(
+        <Carousel
+          testID="issue-862-carousel"
+          style={{ width: 320, height: 180 }}
+          data={["A", "B", "C"]}
+          renderItem={({ index }) => (
+            <Text testID={`issue-862-item-${index}`}>{`Slide ${index}`}</Text>
+          )}
+        />
+      );
+    });
+
+    expect(tree!.root.findAllByProps({ testID: "issue-862-item-0" }).length).toBeGreaterThan(0);
+    expect(
+      tree!
+        .root
+        .findAllByType(Text)
+        .some((node) => node.props.children === "Slide 0")
+    ).toBe(true);
+  });
+});

--- a/example/app/jest.config.cjs
+++ b/example/app/jest.config.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  preset: "jest-expo",
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
+  moduleNameMapper: {
+    "^react$": "<rootDir>/node_modules/react",
+    "^react/jsx-runtime$": "<rootDir>/node_modules/react/jsx-runtime",
+    "^react-native$": "<rootDir>/node_modules/react-native",
+    "^react-native-gesture-handler$": "<rootDir>/node_modules/react-native-gesture-handler",
+    "^react-native-reanimated$": "<rootDir>/node_modules/react-native-reanimated/mock",
+  },
+};

--- a/example/app/jest.setup.js
+++ b/example/app/jest.setup.js
@@ -1,0 +1,1 @@
+require("react-native-gesture-handler/jestSetup");

--- a/example/app/package.json
+++ b/example/app/package.json
@@ -9,11 +9,10 @@
 		"ios": "expo run:ios",
 		"web": "expo start --web -p 8002",
 		"build:web": "expo export --platform web",
-		"test": "jest --watchAll",
+		"test": "jest --config ./jest.config.cjs --watchAll",
+		"test:ci": "jest --config ./jest.config.cjs --watchAll=false --runInBand __tests__/issue-862.carousel-items.test.tsx",
+		"test:issue-862": "jest --config ./jest.config.cjs --watchAll=false --runInBand __tests__/issue-862.carousel-items.test.tsx",
 		"types": "tsc --noEmit"
-	},
-	"jest": {
-		"preset": "jest-expo"
 	},
 	"dependencies": {
 		"@expo/metro-runtime": "~6.1.2",


### PR DESCRIPTION
## Summary
- add an `example/app` Jest harness (`jest.config.cjs` + `jest.setup.js`) that works with linked package source under Expo SDK 54 / RN 0.81
- add a minimal repro test for issue #862 that renders `Carousel` and asserts first item `testID` and text visibility
- add dedicated scripts in `example/app/package.json` for local and CI execution of this regression test

## Why
Issue #862 reports that carousel items do not render in test environment on Expo SDK 54 / RN 0.81.
This PR makes the regression reproducible and keeps it continuously verifiable.

## Validation
- `yarn --cwd example/app test:issue-862` ✅
- verified failure on old `ItemRenderer` behavior (`displayedItems` initially `null`), then pass on current implementation ✅
- root suite smoke check: `yarn test src/components/Carousel.test.tsx --runInBand` ✅

## Scope
- no changes to root `jest.config.js`
- no impact on existing root test pipeline

Closes #862