### PR TITLE
fix(web): keep auto-sized carousel responsive after runtime resize

### DIFF
--- a/src/components/Carousel.test.tsx
+++ b/src/components/Carousel.test.tsx
@@ -1059,5 +1059,83 @@ describe("Test the real swipe behavior of Carousel to ensure it's working as exp
       expect(getByTestId("carousel-item-1")).toBeTruthy();
       expect(getByTestId("carousel-item-2")).toBeTruthy();
     });
+
+    it("should keep auto-sized container responsive and preserve paging after runtime resize", async () => {
+      const initialWidth = 320;
+      const resizedWidth = 520;
+      const offsetTracker = { current: 0 };
+      let nextSlide: ((opts?: { count?: number; animated?: boolean }) => void) | undefined;
+
+      const ResizeAwareCarousel: FC<{ containerWidth: number }> = ({ containerWidth }) => {
+        const scrollOffset = useSharedValue(0);
+
+        useDerivedValue(() => {
+          offsetTracker.current = scrollOffset.value;
+        }, [scrollOffset]);
+
+        return (
+          <Animated.View style={{ width: containerWidth, height: slideHeight }}>
+            <Carousel
+              ref={(ref) => {
+                if (!ref) return;
+                nextSlide = ref.next;
+              }}
+              loop={false}
+              defaultIndex={1}
+              data={createMockData(6)}
+              style={{ height: slideHeight }}
+              defaultScrollOffsetValue={scrollOffset}
+              renderItem={({ item, index }) => (
+                <Animated.View testID={`runtime-resize-item-${index}`} style={{ flex: 1, height: 200 }}>
+                  {item}
+                </Animated.View>
+              )}
+            />
+          </Animated.View>
+        );
+      };
+
+      const { getByTestId, rerender } = render(<ResizeAwareCarousel containerWidth={initialWidth} />);
+
+      const contentContainer = getByTestId("carousel-content-container");
+      expect(contentContainer.props.style[1].width).toBe("100%");
+
+      act(() => {
+        contentContainer.props.onLayout?.({
+          nativeEvent: { layout: { width: initialWidth, height: slideHeight } },
+        } as any);
+        jest.runOnlyPendingTimers();
+      });
+
+      await waitFor(() => {
+        expect(offsetTracker.current).toBe(-initialWidth);
+      });
+
+      expect(getByTestId("carousel-content-container").props.style[1].width).toBe("100%");
+
+      rerender(<ResizeAwareCarousel containerWidth={resizedWidth} />);
+
+      const resizedContentContainer = getByTestId("carousel-content-container");
+      expect(resizedContentContainer.props.style[1].width).toBe("100%");
+
+      act(() => {
+        resizedContentContainer.props.onLayout?.({
+          nativeEvent: { layout: { width: resizedWidth, height: slideHeight } },
+        } as any);
+        jest.runOnlyPendingTimers();
+      });
+
+      await waitFor(() => {
+        expect(offsetTracker.current).toBe(-resizedWidth);
+      });
+
+      act(() => {
+        nextSlide?.({ animated: false });
+      });
+
+      await waitFor(() => {
+        expect(offsetTracker.current).toBe(-(resizedWidth * 2));
+      });
+    });
   });
 });

--- a/src/components/Carousel.test.tsx
+++ b/src/components/Carousel.test.tsx
@@ -1086,7 +1086,10 @@ describe("Test the real swipe behavior of Carousel to ensure it's working as exp
               style={{ height: slideHeight }}
               defaultScrollOffsetValue={scrollOffset}
               renderItem={({ item, index }) => (
-                <Animated.View testID={`runtime-resize-item-${index}`} style={{ flex: 1, height: 200 }}>
+                <Animated.View
+                  testID={`runtime-resize-item-${index}`}
+                  style={{ flex: 1, height: 200 }}
+                >
                   {item}
                 </Animated.View>
               )}
@@ -1095,7 +1098,9 @@ describe("Test the real swipe behavior of Carousel to ensure it's working as exp
         );
       };
 
-      const { getByTestId, rerender } = render(<ResizeAwareCarousel containerWidth={initialWidth} />);
+      const { getByTestId, rerender } = render(
+        <ResizeAwareCarousel containerWidth={initialWidth} />
+      );
 
       const contentContainer = getByTestId("carousel-content-container");
       expect(contentContainer.props.style[1].width).toBe("100%");

--- a/src/components/CarouselLayout.tsx
+++ b/src/components/CarouselLayout.tsx
@@ -10,6 +10,7 @@ import { useOnProgressChange } from "../hooks/useOnProgressChange";
 import { useGlobalState } from "../store";
 import { ICarouselInstance } from "../types";
 import { computedRealIndexWithAutoFillData } from "../utils/computed-with-auto-fill-data";
+import { resolveLayoutSize } from "../utils/resolve-layout-size";
 import { ItemRenderer } from "./ItemRenderer";
 import { ScrollViewGesture } from "./ScrollViewGesture";
 
@@ -46,9 +47,11 @@ export const CarouselLayout = React.forwardRef<ICarouselInstance>((_props, ref) 
     onProgressChange,
     customAnimation,
     defaultIndex,
+    width: legacyWidth,
+    height: legacyHeight,
   } = props;
 
-  const { size, handlerOffset, resolvedSize, sizePhase } = common;
+  const { size, handlerOffset, resolvedSize, sizePhase, sizeExplicit } = common;
   const layoutConfig = useLayoutConfig({ ...props, size });
 
   const isSizeReady = useDerivedValue(() => {
@@ -159,16 +162,22 @@ export const CarouselLayout = React.forwardRef<ICarouselInstance>((_props, ref) 
   const layoutStyle = useAnimatedStyle(() => {
     const { width, height } = flattenedStyle;
     const measuredSize = resolvedSize.value ?? 0;
-
-    const computedWidth = width ?? (vertical ? "100%" : measuredSize || "100%");
-    const computedHeight = height ?? (vertical ? measuredSize || "100%" : "100%");
+    const { computedWidth, computedHeight } = resolveLayoutSize({
+      vertical,
+      styleWidth: width,
+      styleHeight: height,
+      resolvedSize: measuredSize,
+      sizeExplicit,
+      legacyWidth,
+      legacyHeight,
+    });
 
     return {
       width: computedWidth,
       height: computedHeight,
       opacity: isSizeReady.value ? 1 : 0,
     };
-  }, [flattenedStyle, isSizeReady, vertical, resolvedSize, sizePhase]);
+  }, [flattenedStyle, isSizeReady, vertical, resolvedSize, sizePhase, sizeExplicit]);
 
   return (
     <GestureHandlerRootView testID={testID} style={[styles.layoutContainer, style]}>

--- a/src/utils/resolve-layout-size.test.ts
+++ b/src/utils/resolve-layout-size.test.ts
@@ -1,0 +1,40 @@
+import { resolveLayoutSize } from "./resolve-layout-size";
+
+describe("resolveLayoutSize", () => {
+  it("keeps main-axis size responsive in auto-measurement mode", () => {
+    const result = resolveLayoutSize({
+      vertical: false,
+      styleWidth: undefined,
+      styleHeight: 200,
+      resolvedSize: 320,
+    });
+
+    expect(result.computedWidth).toBe("100%");
+    expect(result.computedHeight).toBe(200);
+  });
+
+  it("keeps cross-axis fallback to 100% when not explicitly provided", () => {
+    const result = resolveLayoutSize({
+      vertical: true,
+      styleWidth: undefined,
+      styleHeight: undefined,
+      resolvedSize: 240,
+    });
+
+    expect(result.computedWidth).toBe("100%");
+    expect(result.computedHeight).toBe("100%");
+  });
+
+  it("keeps legacy explicit width fixed on the main axis", () => {
+    const result = resolveLayoutSize({
+      vertical: false,
+      styleWidth: undefined,
+      styleHeight: 200,
+      resolvedSize: 360,
+      legacyWidth: 360,
+    });
+
+    expect(result.computedWidth).toBe(360);
+    expect(result.computedHeight).toBe(200);
+  });
+});

--- a/src/utils/resolve-layout-size.ts
+++ b/src/utils/resolve-layout-size.ts
@@ -27,7 +27,8 @@ export function resolveLayoutSize(params: {
   const lockMainAxis = sizeExplicit || hasLegacyAxisSize;
 
   const computedWidth = styleWidth ?? (vertical ? "100%" : lockMainAxis ? resolvedAxis : "100%");
-  const computedHeight = styleHeight ?? (vertical ? (lockMainAxis ? resolvedAxis : "100%") : "100%");
+  const computedHeight =
+    styleHeight ?? (vertical ? (lockMainAxis ? resolvedAxis : "100%") : "100%");
 
   return { computedWidth, computedHeight };
 }

--- a/src/utils/resolve-layout-size.ts
+++ b/src/utils/resolve-layout-size.ts
@@ -1,0 +1,33 @@
+import type { ViewStyle } from "react-native";
+
+type AxisSize = ViewStyle["width"];
+
+export function resolveLayoutSize(params: {
+  vertical: boolean;
+  styleWidth: AxisSize;
+  styleHeight: AxisSize;
+  resolvedSize: number;
+  sizeExplicit?: boolean;
+  legacyWidth?: number;
+  legacyHeight?: number;
+}) {
+  const {
+    vertical,
+    styleWidth,
+    styleHeight,
+    resolvedSize,
+    sizeExplicit = false,
+    legacyWidth,
+    legacyHeight,
+  } = params;
+  const resolvedAxis = resolvedSize || "100%";
+  const hasLegacyAxisSize = vertical
+    ? typeof legacyHeight === "number" && legacyHeight > 0
+    : typeof legacyWidth === "number" && legacyWidth > 0;
+  const lockMainAxis = sizeExplicit || hasLegacyAxisSize;
+
+  const computedWidth = styleWidth ?? (vertical ? "100%" : lockMainAxis ? resolvedAxis : "100%");
+  const computedHeight = styleHeight ?? (vertical ? (lockMainAxis ? resolvedAxis : "100%") : "100%");
+
+  return { computedWidth, computedHeight };
+}


### PR DESCRIPTION
## Summary
- fix Web auto-size behavior where the carousel main axis was being locked to the first measured pixel size
- keep auto-measurement mode responsive by preserving `100%` on the main axis
- keep existing explicit-size behavior (`itemWidth`/`itemHeight` and legacy `width`/`height`) unchanged
- add a runtime-resize regression test in `Carousel.test.tsx` to verify current page offset and next-page behavior after size changes
- extract and test layout-size resolution logic for stable regression coverage

## Testing
- `yarn test src/components/Carousel.test.tsx`
- `yarn test src/hooks/useCommonVariables.test.tsx`
- `yarn test src/utils/resolve-layout-size.test.ts`

Closes #890