### PR TITLE
fix: ensure useOnProgressChange responds to new offsetX and sizeReady…

### DIFF
--- a/.changeset/cyan-points-wash.md
+++ b/.changeset/cyan-points-wash.md
@@ -1,0 +1,5 @@
+---
+"react-native-reanimated-carousel": patch
+---
+
+Adding `offsetX`/`sizeReady` as internal dependencies of useOnProgressChange to ensure reactivity

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ coverage/
 
 # Issue tasks
 .issue-tasks/
+
+# Agents Docs
+*.local.md

--- a/src/hooks/useOnProgressChange.ts
+++ b/src/hooks/useOnProgressChange.ts
@@ -45,6 +45,6 @@ export function useOnProgressChange(
         else onProgressChange.value = absoluteProgress;
       }
     },
-    [loop, autoFillData, rawDataLength, onProgressChange, size]
+    [loop, autoFillData, rawDataLength, onProgressChange, size, offsetX, sizeReady]
   );
 }


### PR DESCRIPTION
… instances

### Description

`useOnProgressChange` will not re-run `useAnimatedReaction` if new `SharedValue` instances of `offsetX` or `sizeReady` are passed as options because they do not exist in `useAnimatedReaction`'s dependency array.

<img width="713" height="664" alt="image" src="https://github.com/user-attachments/assets/3df1a818-fad6-4962-9f4d-59cb24385e2a" />


Ran into this issue at work and patched it in our project so I wanted to contribute the same fix back to the project.

### Review

- [x] I self-reviewed this PR

### Testing

- [ ] I added/updated tests
- [x] I manually tested

Saw `onProgressChange` called with updated values when given new instances of shared values were passed
