### PR TITLE
fix: ensure useOnProgressChange responds to new offsetX and sizeReady…

### DIFF
--- a/.changeset/cyan-points-wash.md
+++ b/.changeset/cyan-points-wash.md
@@ -1,0 +1,5 @@
+---
+"react-native-reanimated-carousel": patch
+---
+
+Adding `offsetX` as internal dependency of useOnProgressChange to ensure reactivity

--- a/src/hooks/useOnProgressChange.test.tsx
+++ b/src/hooks/useOnProgressChange.test.tsx
@@ -1,4 +1,4 @@
-import { useSharedValue } from "react-native-reanimated";
+import { type SharedValue, useSharedValue } from "react-native-reanimated";
 
 import { renderHook } from "@testing-library/react-hooks";
 
@@ -168,5 +168,46 @@ describe("useOnProgressChange", () => {
 
     mockOffsetX.value = -300;
     expect(mockOnProgressChange).not.toHaveBeenCalled();
+  });
+
+  it("should include offsetX in the dependency array so the reaction re-registers when a new offsetX instance is passed, and should update callback appropriately", () => {
+    const { useAnimatedReaction } = jest.requireMock("react-native-reanimated");
+    const size = 300
+    const progressPct = 0.5
+    const offset = -size * progressPct
+    const mockOffsetX2 = useSharedValue(offset);
+
+    // is one of the values in this dependency array equal to our new mock offset?
+    const containsNewOffset = (deps: unknown[], contains: unknown) => {
+      return deps.reduce((accum: boolean, v: unknown) => {
+        if (v === contains) {
+          return true
+        }
+        return accum
+      }, false)
+    }
+
+
+    const { rerender } = renderHook(
+      ({ offsetX }) =>
+        useOnProgressChange({
+          size: size,
+          autoFillData: false,
+          loop: false,
+          offsetX: offsetX,
+          rawDataLength: 5,
+          onProgressChange: mockOnProgressChange,
+        }),
+      { initialProps: { offsetX: mockOffsetX } }
+    );
+
+    expect(containsNewOffset(useAnimatedReaction.mock.calls[0]?.[2], mockOffsetX2)).toBe(false);
+    expect(mockOnProgressChange).toHaveBeenCalledWith(0, 0);
+
+    // Re-render with a different offsetX instance
+    rerender({ offsetX: mockOffsetX2 });
+
+    expect(containsNewOffset(useAnimatedReaction.mock.calls[1]?.[2], mockOffsetX2)).toBe(true);
+    expect(mockOnProgressChange).toHaveBeenCalledWith(offset, progressPct);
   });
 });

--- a/src/hooks/useOnProgressChange.ts
+++ b/src/hooks/useOnProgressChange.ts
@@ -45,6 +45,6 @@ export function useOnProgressChange(
         else onProgressChange.value = absoluteProgress;
       }
     },
-    [loop, autoFillData, rawDataLength, onProgressChange, size]
+    [loop, autoFillData, rawDataLength, onProgressChange, size, offsetX]
   );
 }


### PR DESCRIPTION
… instances

### Description

`useOnProgressChange` will not re-run `useAnimatedReaction` if new `SharedValue` instance of `offsetX` is passed as option because it doesn't exist in `useAnimatedReaction`'s dependency array.

<img width="689" height="799" alt="image" src="https://github.com/user-attachments/assets/03a4bb98-6abc-4bfa-9b79-99e07cb10ced" />


Ran into this issue at work and patched it in our project so I wanted to contribute the same fix back to the project.

### Review

- [x] I self-reviewed this PR

### Testing

- [x] I added/updated tests
- [x] I manually tested

Saw `onProgressChange` called with updated values when given new instances of shared values were passed
