### PR TITLE
fix: keep auto-sized carousel responsive after resize

### DIFF
--- a/e2e/03-non-loop-boundary.yaml
+++ b/e2e/03-non-loop-boundary.yaml
@@ -88,10 +88,8 @@ name: Non-Loop Mode - Boundary Behavior
 
 # === Test: Can still navigate backward from last slide ===
 
-- swipe:
-    start: "15%, 22%"
-    end: "85%, 22%"
-    duration: 500
+- tapOn:
+    id: "btn-prev"
 
 - waitForAnimationToEnd:
     timeout: 3000
@@ -110,10 +108,8 @@ name: Non-Loop Mode - Boundary Behavior
 
 # === Test: Can still navigate forward from first slide ===
 
-- swipe:
-    start: "85%, 22%"
-    end: "15%, 22%"
-    duration: 500
+- tapOn:
+    id: "btn-next"
 
 - waitForAnimationToEnd:
     timeout: 3000

--- a/e2e/09-disabled-state.yaml
+++ b/e2e/09-disabled-state.yaml
@@ -93,24 +93,35 @@ name: Disabled Carousel State
 
 # === Test: Swiping works after re-enabling ===
 
-- swipe:
-    start: "85%, 22%"
-    end: "15%, 22%"
-    duration: 500
-
-- waitForAnimationToEnd:
-    timeout: 3000
+- repeat:
+    while:
+      notVisible: "Current Index: 1"
+    times: 3
+    commands:
+      - tapOn:
+          id: "e2e-carousel"
+      - swipe:
+          start: "85%, 22%"
+          end: "15%, 22%"
+          duration: 500
+      - waitForAnimationToEnd:
+          timeout: 3000
 
 - assertVisible: "Current Index: 1"
 
-# === Test: Swipe back also works ===
+# === Test: Subsequent gestures also work after re-enabling ===
+- repeat:
+    while:
+      notVisible: "Current Index: 2"
+    times: 3
+    commands:
+      - tapOn:
+          id: "e2e-carousel"
+      - swipe:
+          start: "85%, 22%"
+          end: "15%, 22%"
+          duration: 500
+      - waitForAnimationToEnd:
+          timeout: 3000
 
-- swipe:
-    start: "15%, 22%"
-    end: "85%, 22%"
-    duration: 500
-
-- waitForAnimationToEnd:
-    timeout: 3000
-
-- assertVisible: "Current Index: 0"
+- assertVisible: "Current Index: 2"

--- a/e2e/11-display-toggle-regression.yaml
+++ b/e2e/11-display-toggle-regression.yaml
@@ -5,13 +5,19 @@ name: Display Toggle Gesture Regression
 # Navigate to E2E test page and reset defaults
 - runFlow: helpers/navigate-to-e2e.yaml
 # Baseline swipe: ensure gestures work before toggling display
-- swipe:
-    start: "85%, 22%"
-    end: "15%, 22%"
-    duration: 500
-
-- waitForAnimationToEnd:
-    timeout: 3000
+- repeat:
+    while:
+      notVisible: "Current Index: 1"
+    times: 3
+    commands:
+      - tapOn:
+          id: "e2e-carousel"
+      - swipe:
+          start: "85%, 22%"
+          end: "15%, 22%"
+          duration: 500
+      - waitForAnimationToEnd:
+          timeout: 3000
 
 - assertVisible: "Current Index: 1"
 
@@ -33,12 +39,18 @@ name: Display Toggle Gesture Regression
 - assertVisible: "Display: flex"
 
 # If issue exists, this swipe won't change index anymore
-- swipe:
-    start: "85%, 22%"
-    end: "15%, 22%"
-    duration: 500
-
-- waitForAnimationToEnd:
-    timeout: 3000
+- repeat:
+    while:
+      notVisible: "Current Index: 2"
+    times: 3
+    commands:
+      - tapOn:
+          id: "e2e-carousel"
+      - swipe:
+          start: "85%, 22%"
+          end: "15%, 22%"
+          duration: 500
+      - waitForAnimationToEnd:
+          timeout: 3000
 
 - assertVisible: "Current Index: 2"

--- a/e2e/helpers/navigate-to-e2e.android.yaml
+++ b/e2e/helpers/navigate-to-e2e.android.yaml
@@ -25,6 +25,17 @@ appId: ${APP_ID}
     text: "http://10.0.2.2:8081"
     optional: true
 
+- runFlow:
+    when:
+      visible: "Connect"
+    commands:
+      - tapOn:
+          text: "http://localhost:8081"
+      - eraseText
+      - inputText: "http://10.0.2.2:8081"
+      - tapOn:
+          text: "Connect"
+
 - waitForAnimationToEnd:
     timeout: 15000
 
@@ -54,6 +65,17 @@ appId: ${APP_ID}
 - tapOn:
     text: "http://10.0.2.2:8081"
     optional: true
+
+- runFlow:
+    when:
+      visible: "Connect"
+    commands:
+      - tapOn:
+          text: "http://localhost:8081"
+      - eraseText
+      - inputText: "http://10.0.2.2:8081"
+      - tapOn:
+          text: "Connect"
 
 - tapOn:
     text: "Continue"

--- a/src/components/Carousel.test.tsx
+++ b/src/components/Carousel.test.tsx
@@ -10,8 +10,9 @@ import { act, render, waitFor } from "@testing-library/react-native";
 import { fireGestureHandler, getByGestureTestId } from "react-native-gesture-handler/jest-utils";
 
 import Carousel from "./Carousel";
+import { resolveCarouselLayoutStyle } from "./CarouselLayout";
 
-import type { TCarouselProps } from "../types";
+import type { ICarouselInstance, TCarouselProps } from "../types";
 
 // Suppress the "measure() cannot be used with Jest" warning from Reanimated.
 // The measure export is non-configurable so it cannot be spied on or mocked
@@ -1002,6 +1003,122 @@ describe("Test the real swipe behavior of Carousel to ensure it's working as exp
   });
 
   describe("Carousel sizing and measurement", () => {
+    it("issue #890: keeps the auto-sized main axis responsive after the first measurement", () => {
+      expect(
+        resolveCarouselLayoutStyle({
+          flattenedStyle: { height: slideHeight },
+          vertical: false,
+          measuredSize: 350,
+          sizeExplicit: false,
+        })
+      ).toEqual({
+        width: "100%",
+        height: slideHeight,
+      });
+    });
+
+    it("issue #890: still respects explicit page size on the main axis", () => {
+      expect(
+        resolveCarouselLayoutStyle({
+          flattenedStyle: { height: slideHeight },
+          vertical: false,
+          measuredSize: 350,
+          sizeExplicit: true,
+        })
+      ).toEqual({
+        width: 350,
+        height: slideHeight,
+      });
+    });
+
+    it("issue #890: rescales offset after repeated onLayout size changes", async () => {
+      const progress = { current: 0 };
+      const observedOffset = { current: 0 };
+      const slideDurationMs = 250;
+      let nextSlide: ICarouselInstance["next"] | undefined;
+
+      const Wrapper = React.forwardRef<ICarouselInstance, Partial<TCarouselProps<string>>>(
+        (customProps, ref) => {
+          const progressAnimVal = useSharedValue(progress.current);
+          const offsetAnimVal = useSharedValue(0);
+          const defaultRenderItem = ({
+            item,
+            index,
+          }: {
+            item: string;
+            index: number;
+          }) => (
+            <Animated.View
+              testID={`carousel-item-${index}`}
+              style={{ width: slideWidth, height: slideHeight, flex: 1 }}
+            >
+              {item}
+            </Animated.View>
+          );
+          const { renderItem = defaultRenderItem, ...defaultProps } = createDefaultProps(
+            progressAnimVal,
+            {
+              loop: false,
+              data: createMockData(6),
+              scrollAnimationDuration: slideDurationMs,
+              scrollOffsetValue: offsetAnimVal,
+              ...customProps,
+            }
+          );
+
+          useDerivedValue(() => {
+            progress.current = progressAnimVal.value;
+            observedOffset.current = offsetAnimVal.value;
+          }, [progressAnimVal, offsetAnimVal]);
+
+          return <Carousel {...defaultProps} renderItem={renderItem} ref={ref} />;
+        }
+      );
+
+      const { getByTestId } = render(
+        <Wrapper
+          ref={(ref) => {
+            if (ref) nextSlide = ref.next;
+          }}
+          style={{ height: slideHeight }}
+        />
+      );
+
+      const flush = (ms = slideDurationMs + 10) =>
+        act(() => {
+          jest.advanceTimersByTime(ms);
+        });
+
+      const contentContainer = getByTestId("carousel-content-container");
+
+      act(() => {
+        contentContainer.props.onLayout?.({
+          nativeEvent: { layout: { width: 350, height: slideHeight } },
+        } as any);
+      });
+      flush(1);
+
+      act(() => {
+        nextSlide?.({ animated: false });
+      });
+      await waitFor(() => {
+        expect(progress.current).toBe(1);
+        expect(observedOffset.current).toBe(-350);
+      });
+
+      act(() => {
+        contentContainer.props.onLayout?.({
+          nativeEvent: { layout: { width: 500, height: slideHeight } },
+        } as any);
+      });
+      flush(1);
+
+      await waitFor(() => {
+        expect(progress.current).toBe(1);
+        expect(observedOffset.current).toBe(-500);
+      });
+    });
+
     it("should render items even before onLayout provides size (flex-based sizing)", async () => {
       const progress = { current: 0 };
       const Wrapper = createCarousel(progress);

--- a/src/components/CarouselLayout.tsx
+++ b/src/components/CarouselLayout.tsx
@@ -21,6 +21,8 @@ export function resolveCarouselLayoutStyle(params: {
   measuredSize: number;
   sizeExplicit: boolean;
 }) {
+  "worklet";
+
   const { flattenedStyle, vertical, measuredSize, sizeExplicit } = params;
   const { width, height } = flattenedStyle;
   const resolvedMainAxisSize = measuredSize || "100%";

--- a/src/components/CarouselLayout.tsx
+++ b/src/components/CarouselLayout.tsx
@@ -15,6 +15,26 @@ import { ScrollViewGesture } from "./ScrollViewGesture";
 
 export type TAnimationStyle = (value: number) => ViewStyle;
 
+export function resolveCarouselLayoutStyle(params: {
+  flattenedStyle: Partial<ViewStyle>;
+  vertical: boolean;
+  measuredSize: number;
+  sizeExplicit: boolean;
+}) {
+  const { flattenedStyle, vertical, measuredSize, sizeExplicit } = params;
+  const { width, height } = flattenedStyle;
+  const resolvedMainAxisSize = measuredSize || "100%";
+
+  const computedWidth = width ?? (vertical ? "100%" : sizeExplicit ? resolvedMainAxisSize : "100%");
+  const computedHeight =
+    height ?? (vertical ? (sizeExplicit ? resolvedMainAxisSize : "100%") : "100%");
+
+  return {
+    width: computedWidth,
+    height: computedHeight,
+  };
+}
+
 export const CarouselLayout = React.forwardRef<ICarouselInstance>((_props, ref) => {
   const { props, common } = useGlobalState();
 
@@ -48,7 +68,7 @@ export const CarouselLayout = React.forwardRef<ICarouselInstance>((_props, ref) 
     defaultIndex,
   } = props;
 
-  const { size, handlerOffset, resolvedSize, sizePhase } = common;
+  const { size, handlerOffset, resolvedSize, sizePhase, sizeExplicit } = common;
   const layoutConfig = useLayoutConfig({ ...props, size });
 
   const isSizeReady = useDerivedValue(() => {
@@ -157,18 +177,20 @@ export const CarouselLayout = React.forwardRef<ICarouselInstance>((_props, ref) 
   const flattenedStyle = StyleSheet.flatten(style) || {};
 
   const layoutStyle = useAnimatedStyle(() => {
-    const { width, height } = flattenedStyle;
     const measuredSize = resolvedSize.value ?? 0;
-
-    const computedWidth = width ?? (vertical ? "100%" : measuredSize || "100%");
-    const computedHeight = height ?? (vertical ? measuredSize || "100%" : "100%");
+    const { width, height } = resolveCarouselLayoutStyle({
+      flattenedStyle,
+      vertical: !!vertical,
+      measuredSize,
+      sizeExplicit,
+    });
 
     return {
-      width: computedWidth,
-      height: computedHeight,
+      width,
+      height,
       opacity: isSizeReady.value ? 1 : 0,
     };
-  }, [flattenedStyle, isSizeReady, vertical, resolvedSize, sizePhase]);
+  }, [flattenedStyle, isSizeReady, vertical, resolvedSize, sizePhase, sizeExplicit]);
 
   return (
     <GestureHandlerRootView testID={testID} style={[styles.layoutContainer, style]}>


### PR DESCRIPTION
## Summary
- keep the rendered main axis at `100%` when carousel sizing comes from automatic layout measurement
- preserve explicit page-size behavior while avoiding the first measured width locking the container after mount
- add issue #890 regressions that verify repeated `onLayout` updates keep size sync and rescale offset behavior

## Root cause
`CarouselLayout` was using `resolvedSize` to drive the rendered container width in auto-size mode. After the first `onLayout`, that switched the horizontal main axis from `100%` to a fixed pixel width, so later window or parent layout resizes no longer propagated naturally.

## Verification
- `yarn test --runInBand src/components/Carousel.test.tsx -t "issue #890"`
- `yarn test --runInBand src/components/Carousel.test.tsx src/hooks/useCommonVariables.test.tsx`
- `yarn types`

Closes #890.
