### PR TITLE
test: add issue #862 item rendering regression

### DIFF
--- a/src/components/Carousel.issue-862.test.tsx
+++ b/src/components/Carousel.issue-862.test.tsx
@@ -39,9 +39,13 @@ describe("issue #862 carousel items render in tests", () => {
     expect(tree.root.findAllByProps({ testID: "issue-862-carousel" }).length).toBeGreaterThan(0);
 
     for (const [index, item] of data.entries()) {
-      expect(tree.root.findAllByProps({ testID: `issue-862-item-${item}` }).length).toBeGreaterThan(0);
+      expect(tree.root.findAllByProps({ testID: `issue-862-item-${item}` }).length).toBeGreaterThan(
+        0
+      );
       expect(
-        tree.root.findAllByType(Text).some((node) => node.props.children === `Slide ${index}: ${item}`)
+        tree.root
+          .findAllByType(Text)
+          .some((node) => node.props.children === `Slide ${index}: ${item}`)
       ).toBe(true);
     }
 

--- a/src/components/Carousel.issue-862.test.tsx
+++ b/src/components/Carousel.issue-862.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { Text } from "react-native";
+import renderer, { act } from "react-test-renderer";
+
+import Carousel from "./Carousel";
+
+{
+  const cfg = (global as any).__reanimatedLoggerConfig as
+    | { logFunction: (data: { level: number; message: string }) => void }
+    | undefined;
+  if (cfg) {
+    const originalLog = cfg.logFunction;
+    cfg.logFunction = (data) => {
+      if (data.message.includes("measure() cannot be used with Jest")) return;
+      originalLog(data);
+    };
+  }
+}
+
+describe("issue #862 carousel items render in tests", () => {
+  it("renders carousel items and text nodes, not only the wrapper", async () => {
+    const data = ["A", "B", "C"];
+    let tree!: renderer.ReactTestRenderer;
+
+    await act(async () => {
+      tree = renderer.create(
+        <Carousel
+          testID="issue-862-carousel"
+          style={{ width: 320, height: 180 }}
+          data={data}
+          renderItem={({ item, index }) => (
+            <Text testID={`issue-862-item-${item}`}>{`Slide ${index}: ${item}`}</Text>
+          )}
+        />
+      );
+      await Promise.resolve();
+    });
+
+    expect(tree.root.findAllByProps({ testID: "issue-862-carousel" }).length).toBeGreaterThan(0);
+
+    for (const [index, item] of data.entries()) {
+      expect(tree.root.findAllByProps({ testID: `issue-862-item-${item}` }).length).toBeGreaterThan(0);
+      expect(
+        tree.root.findAllByType(Text).some((node) => node.props.children === `Slide ${index}: ${item}`)
+      ).toBe(true);
+    }
+
+    await act(async () => {
+      tree.unmount();
+      await Promise.resolve();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated Jest regression for issue #862 under `src/components`
- assert the carousel wrapper renders and that item nodes/text are present, not just the wrapper
- keep the change scoped to the issue-specific regression only

Fixes #862

## Verification
- yarn test --runInBand src/components/Carousel.issue-862.test.tsx
- yarn test --runInBand src/components/Carousel.test.tsx
- yarn types