### PR TITLE
fix: accept responsive container styles in sizing warnings

### DIFF
--- a/.changeset/fix-container-size-warning.md
+++ b/.changeset/fix-container-size-warning.md
@@ -1,0 +1,5 @@
+---
+"react-native-reanimated-carousel": patch
+---
+
+- Recognize percentage and flex container styles in development sizing warnings.

--- a/src/hooks/usePropsErrorBoundary.test.tsx
+++ b/src/hooks/usePropsErrorBoundary.test.tsx
@@ -1,0 +1,53 @@
+import { renderHook } from "@testing-library/react-hooks";
+
+import { usePropsErrorBoundary } from "./usePropsErrorBoundary";
+
+import type { TCarouselProps } from "../types";
+
+function createProps(overrides: Partial<TCarouselProps<number>> = {}): TCarouselProps<number> & {
+  dataLength: number;
+} {
+  return {
+    data: [0, 1, 2],
+    dataLength: 3,
+    renderItem: () => null,
+    ...overrides,
+  } as TCarouselProps<number> & { dataLength: number };
+}
+
+describe("usePropsErrorBoundary", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("accepts percentage and flex container sizing without contradictory warnings", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    renderHook(() =>
+      usePropsErrorBoundary(
+        createProps({
+          style: { width: "100%", height: 190 },
+          itemWidth: 280,
+        })
+      )
+    );
+    renderHook(() =>
+      usePropsErrorBoundary(
+        createProps({
+          vertical: true,
+          style: { flex: 1 },
+          itemHeight: 190,
+        })
+      )
+    );
+
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining("Horizontal mode"));
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining("`itemWidth` sets"));
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining("Vertical mode"));
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining("`itemHeight` sets"));
+
+    warnSpy.mockClear();
+    renderHook(() => usePropsErrorBoundary(createProps({ style: { height: 190 } })));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Horizontal mode"));
+  });
+});

--- a/src/hooks/usePropsErrorBoundary.test.tsx
+++ b/src/hooks/usePropsErrorBoundary.test.tsx
@@ -47,7 +47,11 @@ describe("usePropsErrorBoundary", () => {
     expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining("`itemHeight` sets"));
 
     warnSpy.mockClear();
-    renderHook(() => usePropsErrorBoundary(createProps({ style: { height: 190 } })));
+    renderHook(() => usePropsErrorBoundary(createProps({ style: { flex: 0, height: 190 } })));
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Horizontal mode"));
+
+    warnSpy.mockClear();
+    renderHook(() => usePropsErrorBoundary(createProps({ vertical: true })));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Vertical mode"));
   });
 });

--- a/src/hooks/usePropsErrorBoundary.ts
+++ b/src/hooks/usePropsErrorBoundary.ts
@@ -16,7 +16,7 @@ export function usePropsErrorBoundary(props: TCarouselProps & { dataLength: numb
     if (__DEV__) {
       const { style, vertical, width, height, itemWidth, itemHeight, contentContainerStyle } =
         props;
-      const { width: styleWidth, height: styleHeight } = StyleSheet.flatten(style) || {};
+      const { width: styleWidth, height: styleHeight, flex } = StyleSheet.flatten(style) || {};
 
       // Deprecation warnings for width/height props
       if (typeof width === "number" && !warnedRefs.width) {
@@ -42,10 +42,11 @@ export function usePropsErrorBoundary(props: TCarouselProps & { dataLength: numb
       }
 
       // Updated missing size warnings
+      const hasFlexibleContainerSize = typeof flex === "number" && flex > 0;
       const hasHorizontalContainerSize =
-        typeof styleWidth === "number" || typeof width === "number";
+        styleWidth != null || typeof width === "number" || hasFlexibleContainerSize;
       const hasVerticalContainerSize =
-        typeof styleHeight === "number" || typeof height === "number";
+        styleHeight != null || typeof height === "number" || hasFlexibleContainerSize;
 
       if (!vertical && !hasHorizontalContainerSize && !warnedRefs.horizontal) {
         console.warn(


### PR DESCRIPTION
## Summary

- treat percentage dimensions as explicit container sizing in development warnings
- recognize positive `flex` styles as valid layout-driven container sizing
- keep the warning when the carousel truly has no main-axis container sizing
- add regression coverage for horizontal percentage sizing and vertical flex sizing

## Root cause

The warning detector only accepted numeric `style.width` and `style.height` values even though the warning itself recommended percentage dimensions and `flex: 1`. Those valid responsive styles therefore triggered contradictory development warnings while the carousel correctly used layout measurement.

This change only adjusts development warning detection; it does not change runtime measurement or carousel behavior.

## Validation

- Red: the new regression test reproduced all four contradictory warnings on `main`
- Green: `yarn test src/hooks/usePropsErrorBoundary.test.tsx --runInBand`
- `yarn test src/components/Carousel.test.tsx src/hooks/usePropsErrorBoundary.test.tsx --runInBand` (43 tests)
- `yarn test --runInBand` (348 tests)
- `yarn types`
- `yarn lint`
- `yarn changeset:check`
- `yarn prepare`

Fixes #917