### PR TITLE
docs: refresh v5 contributor and API guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,45 +4,40 @@ We want this community to be friendly and respectful to each other. Please follo
 
 ## Development workflow
 
-To get started with the project, run `yarn` in the root directory to install the required dependencies for each package:
+To get started, install the library dependencies in the repository root:
 
 ```sh
-yarn
+yarn install
 ```
 
-> While it's possible to use [`npm`](https://github.com/npm/cli), the tooling is built around [`yarn`](https://classic.yarnpkg.com/), so you'll have an easier time if you use `yarn` for development.
+> The repository declares Yarn 4 in `package.json`; use Yarn so local commands match CI.
 
-While developing, you can run the [example app](/example/expo/) to test your changes. Any changes you make in your library's JavaScript code will be reflected in the example app without a rebuild. If you change any native code, then you'll need to rebuild the example app.
-
-To start build:
+Build the library once, or start the watch task while editing files under `src`:
 
 ```sh
+yarn prepare
+# or
 yarn dev
 ```
 
-To run the example app on Android:
+Install the [Expo example app](./example/app/) dependencies separately, then run the platform you need:
 
 ```sh
-cd example/expo && yarn && yarn android
+cd example/app
+yarn install
+yarn android # or: yarn ios / yarn web
 ```
 
-To run the example app on iOS:
+If native dependencies or configuration change, rebuild the development client with `yarn android` or `yarn ios`.
+
+Before opening a pull request, run the checks relevant to your change from the repository root:
 
 ```sh
-cd example/expo && yarn && yarn ios
-```
-
-To run the example app on Web:
-
-```sh
-cd example/expo && yarn && yarn web
-```
-
-Make sure your code passes TypeScript and Biome checks. Run the following to verify:
-
-```sh
-yarn typescript
+yarn types
 yarn lint
+yarn test
+yarn prepare
+yarn changeset:check
 ```
 
 To fix formatting and linting errors, run the following:
@@ -51,10 +46,12 @@ To fix formatting and linting errors, run the following:
 yarn lint:fix
 ```
 
-Remember to add tests for your change if possible. Run the unit tests by:
+To validate documentation changes, build the website as well:
 
 ```sh
-yarn test
+cd example/website
+yarn install
+yarn build
 ```
 
 ### Commit message convention
@@ -76,30 +73,34 @@ Our pre-commit hooks verify that your commit message matches this format when co
 
 We use [TypeScript](https://www.typescriptlang.org/) for type checking, [Biome](https://biomejs.dev/) for linting and formatting the code, and [Jest](https://jestjs.io/) for testing.
 
-Our pre-commit hooks verify that the linter and tests pass when committing.
+The pre-commit hook applies Biome lint and formatting fixes; CI runs the full type, test, and build checks.
 
-### Publishing to npm
+### Changesets and publishing
 
-We use [release-it](https://github.com/release-it/release-it) to make it easier to publish new versions. It handles common tasks like bumping version based on semver, creating tags and releases etc.
-
-To publish new versions, run the following:
+We use [Changesets](https://github.com/changesets/changesets) for package versions and release notes. For a user-facing library change, add a changeset and keep its summary concise and user-focused:
 
 ```sh
-yarn release
+yarn changeset
+yarn changeset:check
 ```
+
+See [the release-note style guide](./docs/changeset-style.md) for the repository convention. Documentation-only changes do not need a package changeset.
+
+Publishing is performed by the `Changesets` GitHub Actions workflow on `main`. It maintains the release pull request and publishes only after that release pull request is reviewed and merged; contributors should not run `changeset publish` locally.
 
 ### Scripts
 
-The `package.json` file contains various scripts for common tasks:
+The root `package.json` contains scripts for common tasks:
 
-- `yarn bootstrap`: setup project by installing all dependencies and pods.
-- `yarn typescript`: type-check files with TypeScript.
+- `yarn prepare`: build CommonJS, ES module, and TypeScript package outputs.
+- `yarn dev`: rebuild the package when source files change.
+- `yarn types`: type-check source files with TypeScript.
 - `yarn lint`: check files with Biome.
 - `yarn lint:fix`: fix formatting and linting issues with Biome.
 - `yarn test`: run unit tests with Jest.
-- `yarn dev`: start build.
-- `yarn android`: run the example app on Android.
-- `yarn ios`: run the example app on iOS.
+- `yarn e2e:comprehensive`: run the Maestro suite against an already-built example app.
+- `yarn web:smoke`: run the Playwright Web smoke suite.
+- `yarn compat:expo`: validate the packed package in a selected Expo SDK consumer.
 
 ### Sending a pull request
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@ This document provides a comprehensive technical architecture analysis for the `
 
 ### Core Design Philosophy
 
-React Native Reanimated Carousel is a high-performance carousel component built on **React Native Reanimated 2**, adopting the following core design principles:
+React Native Reanimated Carousel is a high-performance carousel component built on **React Native Reanimated 4** and **React Native Worklets**, adopting the following core design principles:
 
 1. **Performance First**: All animation calculations execute on the UI thread, ensuring 60fps smooth experience
 2. **Math-Driven**: Based on precise interpolation algorithms and mathematical transformations to achieve complex animation effects
@@ -20,10 +20,10 @@ React Native Reanimated Carousel is a high-performance carousel component built 
 ### Technology Stack
 
 - **React Native**: Cross-platform mobile application framework
-- **React Native Reanimated 2**: High-performance animation engine
+- **React Native Reanimated 4**: High-performance animation engine
+- **React Native Worklets**: Worklet scheduling and UI/JS runtime interop
 - **React Native Gesture Handler**: Gesture recognition and handling
 - **TypeScript**: Type safety and development experience
-- **Worklets**: UI thread JavaScript execution environment
 
 ---
 
@@ -59,7 +59,7 @@ React Native Reanimated Carousel is a high-performance carousel component built 
 ┌─────────────────────────────────────────────────────────────┐
 │                  🛠️ Foundation Layer                         │
 ├─────────────────────────────────────────────────────────────┤
-│ • React Native Reanimated 2 (SharedValue, Worklets)        │
+│ • Reanimated 4 + React Native Worklets                     │
 │ • React Native Gesture Handler (PanGesture)                │
 │ • React Native Core (View, StyleSheet, Dimensions)         │
 └─────────────────────────────────────────────────────────────┘

--- a/example/website/pages/Examples/basic-layouts/normal.mdx
+++ b/example/website/pages/Examples/basic-layouts/normal.mdx
@@ -71,7 +71,7 @@ function Index() {
 			dataSet={{ kind: "basic-layouts", name: "normal" }}
 		>
 			<Carousel
-				testID={"xxx"}
+				testID={"normal-carousel-demo"}
 				loop={true}
 				snapEnabled={true}
 				pagingEnabled={true}
@@ -84,10 +84,6 @@ function Index() {
 				}}
 				onScrollEnd={() => {
 					console.log("Scroll end");
-				}}
-				onConfigurePanGesture={(g: { enabled: (arg0: boolean) => any }) => {
-					"worklet";
-					g.enabled(false);
 				}}
 				onSnapToItem={(index: number) => console.log("current index:", index)}
 				renderItem={renderItem({ rounded: true })}

--- a/example/website/pages/concepts.mdx
+++ b/example/website/pages/concepts.mdx
@@ -115,49 +115,47 @@ So when the first one is at the origin `translateX:0`, the next one is at the or
 ### Directory
 ```
 ./src
-├── Carousel.tsx # RNRC component `entry file`
-├── LazyView.tsx # ShouldUpdate prop controls whether to display elements
-├── ScrollViewGesture.tsx # Gesture logic `entry file`
-├── constants
-│   └── index.ts # Constants defined
+├── components
+│   ├── Carousel.tsx # Public component facade
+│   ├── CarouselLayout.tsx # Layout, progress, controller, and autoplay wiring
+│   ├── ItemLayout.tsx # Per-item animated layout
+│   ├── ItemRenderer.tsx # Visible-item rendering
+│   ├── LazyView.tsx # Conditional item rendering
+│   ├── Pagination # Basic and custom pagination
+│   └── ScrollViewGesture.tsx # Pan gesture and boundary handling
 ├── hooks
-│   ├── useAutoPlay.ts # Managing Auto Play
-│   ├── useCarouselController.tsx # The controller that manages the behavior of the multicast graph (previous, next...)
-│   ├── useCheckMounted.ts # Check whether the wheel cast diagram has been mounted
-│   ├── useCommonVariables.ts # Pull some common variables from Props
-│   ├── useInitProps.ts # Initialize the Props passed in
-│   ├── useLayoutConfig.ts # parallax, horizontal-stack... Returns different animationStyles
-│   ├── useOffsetX.ts # The core logic of when to move the end slide to the start position
-│   ├── useOnProgressChange.ts # Listen for scrolling progress changes
-│   ├── usePropsErrorBoundary.ts # Used to catch setup errors for Props
-│   └── useVisibleRanges.tsx # Manages the visibility of the carousel elements
-├── index.tsx
-├── layouts # Some basic layouts are defined
-│   ├── BaseLayout.tsx
-│   ├── index.tsx # Layout entry file that returns the various animationStyles defined.
+│   ├── useAutoPlay.ts # Autoplay timer lifecycle
+│   ├── useCarouselController.tsx # prev, next, scrollTo, and current index
+│   ├── useCommonVariables.ts # Shared size and offset state
+│   ├── useLayoutConfig.ts # Selects normal, parallax, or stack animations
+│   ├── useOffsetX.ts # Loop-aware item positioning
+│   ├── useOnProgressChange.ts # Progress callbacks and shared values
+│   ├── usePanGestureProxy.ts # Gesture configuration
+│   └── useVisibleRanges.tsx # Render-window calculation
+├── layouts
+│   ├── index.tsx
 │   ├── normal.ts
 │   ├── parallax.ts
 │   └── stack.ts
 ├── store
-│   └── index.ts # ContextStore for Props and some base variables
-├── types.ts # The type definition
-└── utils # Some tool methods.
-    ├── computedWithAutoFillData.ts # When the default data is insufficient, the data will be automatically completed and can also be turned off with `autoFillData` prop, so this file provides ways to handle two different cases.
-    ├── dealWithAnimation.ts # Encapsulates and handles both Spring/Timing animation types
-    └── log.ts # The utility method used to type logs in `worklet` functions
+│   └── index.tsx # Context for props, shared state, and measurements
+├── utils # Pure offset, gesture, animation, and data helpers
+├── index.tsx # Package exports
+└── types.ts # Public prop and ref types
 ```
 
 ### Development
-1. Run `yarn dev` in the root directory.
-2. Run `yarn ios/ yarn android/yarn web` on exampleExpo.
-3. Modify the files under './src/*'to see the changes.
+1. Run `yarn install` and `yarn dev` in the repository root.
+2. Run `yarn install` in `example/app` once.
+3. Start the example with `yarn ios`, `yarn android`, or `yarn web` from `example/app`.
+4. Modify files under `src`; the root watch task rebuilds the linked package.
 
 ### Tips
 How to add a new animation effect?
 
-We recommend you to use [customAnimation](/custom-animations.md) prop to do this, as this is a more flexible and easy way to do it.
+Use the [`customAnimation`](/custom-animations) prop for animation effects that are not covered by the built-in layouts.
 
-1. In `./exampleExpo/src/pages/[new example]`reference other examples to create a new animation and give it a name (kebab-case dash name).
-2. In the `./exampleExpo/src/pages/Home.tsx ` file to add the entrance route.
-3. Record the demo animation. We recommend that you record the demo animation at a size of 1.8:1, usually in the same proportion as other demo GIF. Running 'yarn gif' in the root directory will automatically generate GIF files in this directory.
-4. Put the GIF files into the `./assets` directory and update the `README.md` and `README.zh-cn. md` files according to their types.
+1. Add a kebab-case demo route under `example/app/app/demos/<category>/<name>` by following a nearby example.
+2. Add or update the matching page under `example/website/pages/Examples` when the demo should appear in the documentation.
+3. Record the demo and run `yarn gif` from the repository root when a GIF asset is needed.
+4. Put generated media under `assets` and reference it from the example page.

--- a/example/website/pages/faq.mdx
+++ b/example/website/pages/faq.mdx
@@ -29,31 +29,48 @@ When rendering a large number of elements, you can use the 'windowSize' property
 
 ## Used in `ScrollView/FlatList`
 
-**[#143](https://github.com/dohooo/react-native-reanimated-carousel/issues/143) - Carousel suppresses ScrollView/FlatList scroll gesture handler:** When using a carousel with a layout oriented to only one direction (vertical/horizontal) and inside a ScrollView/FlatList, it is important for the user experience that the unused axis does not impede the scroll of the list. So that, for example, the x-axis is free we can change the [activeOffsetX](https://docs.swmansion.com/react-native-gesture-handler/docs/1.10.3/api/gesture-handlers/pan-gh/#activeoffsetx) of the gesture handler:
+**[#143](https://github.com/dohooo/react-native-reanimated-carousel/issues/143) - Carousel suppresses ScrollView/FlatList scroll gesture handler:** When a horizontal carousel is nested in a vertical `ScrollView` or `FlatList`, configure the pan gesture so small horizontal movement does not capture the parent scroll. For example, use Gesture Handler's [`activeOffsetX`](https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture/#activeoffsetx):
 
 ```tsx copy
 <Carousel
   {...}
-  onConfigurePanGesture={gestureChain => (
-    gestureChain.activeOffsetX([-10, 10])
-  )}
+  onConfigurePanGesture={(gesture) => {
+    gesture.activeOffsetX([-10, 10]);
+  }}
 />
 ```
 
 ## RTL
 Support to RTL mode with no more configuration needed. But in RTL mode, need to manually set the autoPlayReverse props for autoplay to control scrolling direction.
 
-## EXPO
-If use EXPO managed workflow please ensure that the version is greater than 41.Because the old version not support `Reanimated(v2)`.
+## Expo
+
+Install the v5 beta and its native peers with `expo install` so Expo selects compatible versions:
+
+```shell copy
+npx expo install react-native-reanimated-carousel@beta react-native-reanimated react-native-worklets react-native-gesture-handler
+```
+
+The v5 beta requires React Native 0.80+, Reanimated 4.1+, and React Native Worklets 0.5+. See the [v5 migration guide](/migration-v5) for the validated Expo matrix and setup notes.
 
 ## Working principle
 [How it works?](/concepts)
 
-## How to run tests in `example/expo`
+## How to run the example app
+
+Build the package, then install and run the Expo app from its current location:
+
 ```shell copy
-$ yarn prepare
-$ yarn link --global
-$ cd ./example/expo
-$ yarn link react-native-reanimated-carousel --global
-$ yarn test
+yarn prepare
+cd example/app
+yarn install
+yarn ios # or: yarn android / yarn web
+```
+
+Run the library checks from the repository root:
+
+```shell copy
+yarn test
+yarn types
+yarn lint
 ```

--- a/example/website/pages/programmatic-control.mdx
+++ b/example/website/pages/programmatic-control.mdx
@@ -139,6 +139,10 @@ const currentIndex = carouselRef.current?.getCurrentIndex();
 console.log('Current index:', currentIndex);
 ```
 
+<Callout type="warning">
+  Do not call `getCurrentIndex()` during render. It reads live animation state; call it from an event handler or an effect instead.
+</Callout>
+
 ## Practical Examples
 
 ### Pagination Control
@@ -219,30 +223,22 @@ When updating data and needing to scroll to new items:
 function DynamicCarousel() {
   const carouselRef = useRef<ICarouselInstance>(null);
   const [items, setItems] = useState(initialItems);
+  const [pendingIndex, setPendingIndex] = useState<number | null>(null);
 
   const addItemAndNavigate = (newItem) => {
-    const newItems = [...items, newItem];
-    setItems(newItems);
-    
-    // Wait for next render cycle before scrolling
-    setTimeout(() => {
-      carouselRef.current?.scrollTo({
-        index: newItems.length - 1,
-        animated: true
-      });
-    }, 0);
+    setPendingIndex(items.length);
+    setItems((currentItems) => [...currentItems, newItem]);
   };
 
-  // Alternative: Use useEffect to handle timing
   useEffect(() => {
-    if (items.length > initialItems.length) {
-      // Scroll to the last item when new items are added
-      carouselRef.current?.scrollTo({
-        index: items.length - 1,
-        animated: true
-      });
-    }
-  }, [items]);
+    if (pendingIndex === null || pendingIndex >= items.length) return;
+
+    carouselRef.current?.scrollTo({
+      index: pendingIndex,
+      animated: true
+    });
+    setPendingIndex(null);
+  }, [items.length, pendingIndex]);
 
   return (
     <Carousel
@@ -327,7 +323,7 @@ function SearchableCarousel() {
 ## Important Notes
 
 <Callout type="warning">
-  **Race Condition Warning:** When updating data and immediately calling scroll methods, you might encounter race conditions. The carousel may not have rendered the new data yet. Use `setTimeout` or `useEffect` to ensure proper timing.
+  **Data update timing:** Do not update `data` and call a scroll method in the same render path. Wait for the updated data to render, for example by issuing the scroll from an effect.
 </Callout>
 
 <Callout type="info">

--- a/example/website/pages/props.mdx
+++ b/example/website/pages/props.mdx
@@ -27,8 +27,8 @@ import { Callout } from 'nextra/components'
 
 ## Basic
 
-<Callout emoji="🙋‍♂️">
-Basically, each props should have a corresponding example, which is more intuitive, but due to time constraints, it has not been done for the time being. It is expected that someone can contribute to submit PR.
+<Callout type="info">
+This page documents the v5 beta API. The exported TypeScript types remain the source of truth for exact signatures.
 </Callout>
 
 ### `data`
@@ -107,15 +107,15 @@ Carousel Animated transitions
 
 | type   | default | required |
 | ------ | ------- | -------- |
-| 'horizontal-stack'\|'vertical-stack'\|'parallax' | default     | ❌      |
+| 'horizontal-stack' \| 'vertical-stack' \| 'parallax' | undefined (normal layout) | ❌ |
 
 ### `modeConfig`
 
-Different modes correspond to different configurations. For details, see below\[modeConfig\]\(#`modeConfig` Props\)
+Mode-specific animation configuration. See the Parallax Mode and Stack Mode sections below.
 
 | type   | default | required |
 | ------ | ------- | -------- |
-| \{moveSize\?: number;stackInterval\?: number;scaleInterval\?: number;rotateZDeg\?: number;snapDirection\?: 'left' \| 'right';\} | -     | ❌      |
+| object | \{\} | ❌ |
 
 ### `style`
 
@@ -270,13 +270,13 @@ The callback provides two parameters: `offsetProgress`:Total of offset distance 
 | ------ | ------- | -------- |
 | \(\(offsetProgress: number, absoluteProgress: number\) => void\) \| SharedValue\<number\> | -     | ❌      |
 
-### `modeConfig`
+### `onLayout`
 
-Stack layout animation style
+Called when the carousel content container is laid out.
 
 | type   | default | required |
 | ------ | ------- | -------- |
-| \{moveSize\?: number;stackInterval\?: number;scaleInterval\?: number;rotateZDeg\?: number;snapDirection\?: 'left' \| 'right';\} | \{ snapDirection: 'left',moveSize: window.width,stackInterval: 30,scaleInterval: 0.08,rotateZDeg: 135\}     | ❌      |
+| \(event: LayoutChangeEvent\) => void | - | ❌ |
 
 ### `pagingEnabled`
 
@@ -302,6 +302,16 @@ If enabled, releasing the touch will scroll to the nearest item, valid when pagi
 | ------ | ------- | -------- |
 | boolean | true     | ❌      |
 
+### `enableSnap`
+
+> @deprecated Use `snapEnabled` instead.
+
+Legacy name for `snapEnabled`.
+
+| type   | default | required |
+| ------ | ------- | -------- |
+| boolean | - | ❌ |
+
 ### `enabled`
 
 when false, Carousel will not respond to any gestures
@@ -316,7 +326,7 @@ If positive, the carousel will scroll to the positive direction and vice versa.
 
 | type   | default | required |
 | ------ | ------- | -------- |
-| 'positive' \| 'negative | -     | ❌      |
+| 'positive' \| 'negative' | -     | ❌      |
 
 ### `customConfig`
 
@@ -328,11 +338,11 @@ Custom carousel config
 
 ### `customAnimation`
 
-Custom animations. For details, see below\[custom animation\]\(.\/custom-animation.md\)
+Custom worklet animation. See [Custom Animations](/custom-animations).
 
 | type   | default | required |
 | ------ | ------- | -------- |
-| \(value: number\) => ViewStyle | -     | ❌      |
+| \(value: number, index: number\) => ViewStyle | -     | ❌      |
 
 ### `maxScrollDistancePerSwipe`
 
@@ -386,14 +396,14 @@ control prev/next item scale
 
 | type   | default | required |
 | ------ | ------- | -------- |
-| number | parallaxAdjacentItemScale \|\| Math.pow\(parallaxScrollingScale, 2\)     | ❌      |
+| number | parallaxScrollingScale ** 2 | ❌ |
 
 ## Stack Mode
 
 ```tsx copy
 <Carousel
     {...restProps}
-    mode="stack"
+    mode="horizontal-stack"
     modeConfig={{
         moveSize: 200,
         stackInterval: 30,
@@ -403,6 +413,14 @@ control prev/next item scale
     }}
 />
 ```
+
+### `showLength`
+
+Maximum number of cards shown in the stack. By default, the stack can show the remaining data length.
+
+| type   | default | required |
+| ------ | ------- | -------- |
+| number | data length - 1 | ❌ |
 
 ### `stackInterval`
 
@@ -544,7 +562,7 @@ Scroll to previous item, it takes one optional argument \(count\), which allows 
 
 | type   |
 | ------ |
-| \(\{ count: number, animated: boolean, onFinished?: \(\) => void \}\) \=\> void |
+| \(options?: \{ count?: number, animated?: boolean, onFinished?: \(\) => void \}\) => void |
 
 ### `next`
 
@@ -552,7 +570,7 @@ Scroll to next item, it takes one optional argument \(count\), which allows you 
 
 | type   |
 | ------ |
-| \(\{ count: number, animated: boolean, onFinished?: \(\) => void \}\) => void |
+| \(options?: \{ count?: number, animated?: boolean, onFinished?: \(\) => void \}\) => void |
 
 ### `scrollTo`
 
@@ -564,11 +582,11 @@ Use count to scroll to a position where relative to the current position, scroll
 
 | type   |
 | ------ |
-| \(\{ index: number, count: number, animated: boolean, onFinished\?: \(\) => void \}\) => void |
+| \(options?: \{ index?: number, count?: number, animated?: boolean, onFinished\?: \(\) => void \}\) => void |
 
 ### `getCurrentIndex`
 
-Get current item index
+Get the current item index. Call this from an event handler or effect, not while React is rendering.
 
 | type   |
 | ------ |

--- a/src/types.ts
+++ b/src/types.ts
@@ -242,7 +242,7 @@ export type TCarouselProps<T = any> = {
   customConfig?: CustomConfig | (() => CustomConfig);
   /**
    * Custom animations.
-   * Must use `worklet`, Details: https://docs.swmansion.com/react-native-reanimated/docs/2.2.0/worklets/
+   * Must be worklet-compatible. See https://docs.swmansion.com/react-native-reanimated/docs/guides/worklets/
    * @test_coverage ✅ tested in Carousel.test.tsx > should apply the custom animation
    */
   customAnimation?: (value: number, index: number) => ViewStyle;


### PR DESCRIPTION
## Summary

- align the contributor workflow with the current `example/app`, Yarn scripts, Changesets release flow, and CI checks
- refresh the v5 FAQ, architecture overview, development paths, and programmatic-control guidance
- correct the Props reference against the exported v5 types, including mode values, defaults, callbacks, deprecated aliases, and ref signatures
- regenerate the normal-layout website example so it no longer publishes a gesture-disabled demo

## Verification

- `yarn types`
- `yarn lint`
- `yarn test --runInBand` (30 suites, 356 tests)
- `yarn prepare`
- `yarn changeset:check`
- `yarn build` in `example/website` (34 static pages)

## Release impact

Documentation and type-comment corrections only. No runtime behavior changed, so this PR intentionally does not add a Changeset.
