### PR TITLE
fix: remove nested gesture handler root

### DIFF
--- a/.changeset/fix-nested-gesture-root.md
+++ b/.changeset/fix-nested-gesture-root.md
@@ -1,0 +1,6 @@
+---
+"react-native-reanimated-carousel": patch
+---
+
+- Remove the nested `GestureHandlerRootView` so correctly configured apps no longer log the Android parent-root warning (Issue #921).
+- Preserve carousel navigation and gestures by relying on the application-level Gesture Handler root required during installation.

--- a/src/components/Carousel.gesture-root.test.tsx
+++ b/src/components/Carousel.gesture-root.test.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { View } from "react-native";
+
+import { render } from "@testing-library/react-native";
+
+import Carousel from "./Carousel";
+
+jest.mock("react-native-gesture-handler", () => {
+  const actual = jest.requireActual("react-native-gesture-handler");
+  const React = jest.requireActual("react");
+  const { View } = jest.requireActual("react-native");
+
+  return {
+    ...actual,
+    GestureHandlerRootView: ({ children, ...props }: { children?: React.ReactNode }) =>
+      React.createElement(
+        View,
+        { ...props, accessibilityLabel: "nested-gesture-handler-root" },
+        children
+      ),
+  };
+});
+
+jest.mock("./ItemRenderer", () => ({ ItemRenderer: () => null }));
+
+describe("Carousel gesture-handler root", () => {
+  it("relies on the root configured by the application", async () => {
+    const screen = render(
+      <Carousel
+        data={["A"]}
+        renderItem={({ index }) => <View testID={`carousel-item-${index}`} />}
+        style={{ width: 300, height: 200 }}
+      />
+    );
+
+    expect(screen.queryByLabelText("nested-gesture-handler-root")).toBeNull();
+  });
+});

--- a/src/components/CarouselLayout.tsx
+++ b/src/components/CarouselLayout.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { StyleSheet, type ViewStyle } from "react-native";
-import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { StyleSheet, View, type ViewStyle } from "react-native";
 import { useAnimatedReaction, useAnimatedStyle, useDerivedValue } from "react-native-reanimated";
 import { scheduleOnRN } from "react-native-worklets";
 import { useAutoPlay } from "../hooks/useAutoPlay";
@@ -214,7 +213,7 @@ export const CarouselLayout = React.forwardRef<ICarouselInstance>((_props, ref) 
   ]);
 
   return (
-    <GestureHandlerRootView testID={testID} style={[styles.layoutContainer, style]}>
+    <View testID={testID} style={[styles.layoutContainer, style]}>
       <ScrollViewGesture
         size={size}
         key={mode}
@@ -248,7 +247,7 @@ export const CarouselLayout = React.forwardRef<ICarouselInstance>((_props, ref) 
           customAnimation={customAnimation}
         />
       </ScrollViewGesture>
-    </GestureHandlerRootView>
+    </View>
   );
 });
 


### PR DESCRIPTION
## Summary

- replace the carousel's internal `GestureHandlerRootView` with a regular React Native `View`
- rely on the application-level Gesture Handler root already required by the installation guide
- add a regression test and a patch changeset

## Root cause

The carousel mounted its own `GestureHandlerRootView` even when the application was already wrapped at the root. On Android this created a nested Gesture Handler root and emitted `Gesture handler is already enabled for a parent view` every time the carousel screen mounted.

## Validation

- reproduced the warning with the published `5.0.0-beta.7` package in an Expo SDK 57 / React Native 0.86 native-stack app
- reproduced with both React Native Gesture Handler 2.32.0 and 3.1.0: two screen mounts produced two warnings in each matrix entry
- packed and installed this branch into the same native consumer; the same two-mount navigation and swipe flow produced zero warnings with both Gesture Handler versions
- verified first mount, imperative next navigation, swipe navigation, back navigation, and second mount in Maestro
- added a Jest regression test that failed before the fix and passes after it
- `yarn test --runInBand` (31 suites, 357 tests)
- `yarn types`
- `yarn lint`
- `yarn changeset:check`
- `yarn prepare`

The separate first-mount freeze described in the issue did not reproduce in either current-v5 matrix entry; the complete interaction flow passed before and after this warning fix.

Fixes #921
