### PR TITLE
docs: polish v5 beta onboarding and package hygiene

### DIFF
--- a/.changeset/clean-package-tests.md
+++ b/.changeset/clean-package-tests.md
@@ -1,0 +1,5 @@
+---
+"react-native-reanimated-carousel": patch
+---
+
+- Exclude test files from published package tarballs while keeping the React Native source entry intact.

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: [dohooo, gxxgcn, oliverloops]
+github: [dohooo, oliverloops]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -4,51 +4,37 @@ about: Thanks for taking the time to fill out this bug report!
 title: ''
 labels: bug
 assignees: dohooo
-
 ---
 
+<!-- Before filing, search existing issues and confirm the problem on the latest v5 beta. -->
 
-
-
-<!---
-I am still actively maintaining this project, but because I have more work to do in life, I will only deal with problems on weekends at present. If you have important and urgent problems, you can ask me to give some time for you through Sponsor. ❤️
--->
-
-
-
-
-
-<!---
-Any problem that does not include an accurate reproduction step is likely to be closed 
--->
 **Describe the bug**
-A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+A clear description of what happened and whether this is a regression.
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+**Reproduction**
+Link to a minimal repository or Expo Snack that reproduces the problem, then list the shortest steps needed to see it. Issues that cannot be reproduced may be closed until more information is available.
+
+1. ...
+2. ...
+3. ...
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+A clear description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Environment**
 
-**Versions (please complete the following information):**
- - react: v0.0.0  
- - react-native: v0.0.0  
- - react-native-reanimated: v0.0.0    
- - react-native-reanimated-carousel: v0.0.0  
- - react-native-gesture-handler: v0.0.0  
+- react-native-reanimated-carousel:
+- react-native / Expo SDK:
+- react:
+- react-native-reanimated:
+- react-native-worklets:
+- react-native-gesture-handler:
+- platform and OS:
+- device or simulator:
+- New Architecture enabled: yes / no
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+**Logs, screenshots, or video**
+Include the complete error and any visual evidence that makes the behavior easier to verify.
 
 **Additional context**
-Add any other context about the problem here.
+Add anything else that may affect the reproduction.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,28 +4,16 @@ about: Suggest an idea for this project
 title: ''
 labels: enhancement
 assignees: dohooo
-
 ---
 
-
-
-
-<!---
-I am still actively maintaining this project, but because I have more work to do in life, I will only deal with problems on weekends at present. If you have important and urgent problems, you can ask me to give some time for you through Sponsor. ❤️
--->
-
-
-
-
-
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+Describe the user problem and why the existing v5 API cannot solve it.
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+Describe the API or behavior you would like, with a short usage example when possible.
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+Describe workarounds or alternative APIs you considered.
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+Add related issues, libraries, screenshots, or performance considerations.

--- a/.github/ISSUE_TEMPLATE/improve-documentation.md
+++ b/.github/ISSUE_TEMPLATE/improve-documentation.md
@@ -4,18 +4,13 @@ about: Suggest improvements to the Documentation. If this doesn’t look right.
 title: ''
 labels: documentation
 assignees: dohooo
-
 ---
 
+**Page or section**
+Link to the page or name the documentation section that should change.
 
+**What is unclear or missing?**
+Describe the problem and the reader task it blocks.
 
-
-<!---
-I am still actively maintaining this project, but because I have more work to do in life, I will only deal with problems on weekends at present. If you have important and urgent problems, you can ask me to give some time for you through Sponsor. ❤️
--->
-
-
-
-
-
-
+**Suggested improvement**
+Describe the correction, example, or structure you would find more useful.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,8 @@
 
 ### Testing
 
-- [ ] I added/updated tests
-- [ ] I manually tested
+- [ ] I added or updated automated tests where applicable
+- [ ] I manually tested the affected platform or documentation
+- [ ] I added a changeset for a user-facing package change, or this change is docs-only/internal
 
-<!-- Describe any manual testing -->
+<!-- List the exact commands, devices, or pages used for verification -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ### Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the project maintainer at [zhaodonghao586@outlook.com](mailto:zhaodonghao586@outlook.com). All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 <img src="assets/home-banner.png" width="100%"/>
 
-![Hacktober Badge](https://img.shields.io/badge/hacktoberfest-2022-blueviolet)
 ![platforms](https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Web-brightgreen.svg?style=flat-square&colorB=191A17)
-[![npm](https://img.shields.io/npm/v/react-native-reanimated-carousel.svg?style=flat-square)](https://www.npmjs.com/package/react-native-reanimated-carousel)
+[![npm beta](https://img.shields.io/npm/v/react-native-reanimated-carousel/beta.svg?style=flat-square&label=beta)](https://www.npmjs.com/package/react-native-reanimated-carousel)
 [![npm](https://img.shields.io/npm/dm/react-native-reanimated-carousel.svg?style=flat-square&colorB=007ec6)](https://www.npmjs.com/package/react-native-reanimated-carousel)
 [![npm](https://img.shields.io/npm/dw/react-native-reanimated-carousel.svg?style=flat-square&colorB=007ec6)](https://www.npmjs.com/package/react-native-reanimated-carousel)
 [![github issues](https://img.shields.io/github/issues/dohooo/react-native-reanimated-carousel.svg?style=flat-square)](https://github.com/dohooo/react-native-reanimated-carousel/issues)
@@ -41,6 +40,37 @@ yarn add react-native-reanimated-carousel@beta react-native-reanimated react-nat
 ```
 
 Follow the official setup instructions for [Reanimated](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started) and [Gesture Handler](https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation). When upgrading from v4, read the [v5 migration guide](https://rn-carousel.dev/migration-v5).
+
+## Quick start
+
+```tsx
+import * as React from "react";
+import { Text, useWindowDimensions, View } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import Carousel from "react-native-reanimated-carousel";
+
+const data = ["First", "Second", "Third"];
+
+export default function App() {
+  const { width } = useWindowDimensions();
+
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <View style={{ flex: 1, justifyContent: "center" }}>
+        <Carousel
+          style={{ width, height: 200 }}
+          data={data}
+          renderItem={({ item }) => (
+            <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+              <Text>{item}</Text>
+            </View>
+          )}
+        />
+      </View>
+    </GestureHandlerRootView>
+  );
+}
+```
 
 ## 📊 Version Compatibility
 

--- a/example/app/app/demos/basic-layouts/stack/index.tsx
+++ b/example/app/app/demos/basic-layouts/stack/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { View } from "react-native";
 import type { StyleProp, ViewStyle } from "react-native";
-import Carousel, { ICarouselInstance, TCarouselProps } from "react-native-reanimated-carousel";
+import Carousel, { ICarouselInstance } from "react-native-reanimated-carousel";
 
 import { CustomSelectActionItem } from "@/components/ActionItems";
 import { CarouselAdvancedSettingsPanel } from "@/components/CarouselAdvancedSettingsPanel";
@@ -23,39 +23,23 @@ function Index() {
       autoPlayInterval: 2000,
       autoPlayReverse: false,
       data: defaultDataWith6Colors,
-      height: 258,
       loop: true,
       pagingEnabled: true,
       snapEnabled: true,
       vertical: false,
-      width: window.width,
     },
   });
 
-  const {
-    width,
-    height,
-    style: advancedStyle,
-    ...restSettings
-  } = advancedSettings as {
-    width?: number;
-    height?: number;
-    style?: StyleProp<ViewStyle>;
-  } & TCarouselProps;
-
-  const baseDimensions = React.useMemo(() => {
-    if (typeof width === "number" || typeof height === "number") {
-      return { width, height };
-    }
-    return { width: 280, height: 210 };
-  }, [width, height]);
+  const { style: advancedStyle, ...restSettings } = advancedSettings;
 
   const mergedStyle = React.useMemo<StyleProp<ViewStyle>>(
     () =>
-      [baseDimensions, { alignItems: "center", justifyContent: "center" }, advancedStyle].filter(
-        Boolean
-      ) as StyleProp<ViewStyle>[],
-    [baseDimensions, advancedStyle]
+      [
+        { width: window.width, height: 258 },
+        { alignItems: "center", justifyContent: "center" },
+        advancedStyle,
+      ].filter(Boolean) as StyleProp<ViewStyle>[],
+    [advancedStyle]
   );
 
   return (

--- a/example/website/components/Badges.tsx
+++ b/example/website/components/Badges.tsx
@@ -4,16 +4,12 @@ export const Badges = () => {
       {
         [
           {
-            label: "Hacktober Badge",
-            url: "https://img.shields.io/badge/hacktoberfest-2022-blueviolet",
-          },
-          {
             label: "platforms",
             url: "https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Web-brightgreen.svg?style=flat-square&colorB=191A17",
           },
           {
-            label: "npm",
-            url: "https://img.shields.io/npm/v/react-native-reanimated-carousel.svg?style=flat-square",
+            label: "npm beta",
+            url: "https://img.shields.io/npm/v/react-native-reanimated-carousel/beta.svg?style=flat-square&label=beta",
           },
           {
             label: "npm",

--- a/example/website/pages/Examples/summary.mdx
+++ b/example/website/pages/Examples/summary.mdx
@@ -37,12 +37,18 @@ import { Cards } from 'nextra/components'
 import Link from 'next/link'
 import posthog from "posthog-js";
 
+export const captureExampleClick = (name, kind) => {
+  if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+    posthog.capture('example-clicked', { name, kind });
+  }
+};
+
 
 ### Basic Layouts
 
 <Cards num={2}>
   
-        <Link href="/Examples/basic-layouts/stack" onClick={() => posthog.capture('example-clicked', { name: 'stack', kind: 'basic-layouts' })}>
+        <Link href="/Examples/basic-layouts/stack" onClick={() => captureExampleClick('stack', 'basic-layouts')}>
           <div className='summary-item'>
             <div className='image-container'>![basic-layouts-stack](../../../app/app/demos/basic-layouts/stack/preview.png)</div>
             <div className='label-container'>
@@ -52,7 +58,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/basic-layouts/parallax" onClick={() => posthog.capture('example-clicked', { name: 'parallax', kind: 'basic-layouts' })}>
+        <Link href="/Examples/basic-layouts/parallax" onClick={() => captureExampleClick('parallax', 'basic-layouts')}>
           <div className='summary-item'>
             <div className='image-container'>![basic-layouts-parallax](../../../app/app/demos/basic-layouts/parallax/preview.png)</div>
             <div className='label-container'>
@@ -62,7 +68,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/basic-layouts/normal" onClick={() => posthog.capture('example-clicked', { name: 'normal', kind: 'basic-layouts' })}>
+        <Link href="/Examples/basic-layouts/normal" onClick={() => captureExampleClick('normal', 'basic-layouts')}>
           <div className='summary-item'>
             <div className='image-container'>![basic-layouts-normal](../../../app/app/demos/basic-layouts/normal/preview.png)</div>
             <div className='label-container'>
@@ -72,7 +78,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/basic-layouts/left-align" onClick={() => posthog.capture('example-clicked', { name: 'left-align', kind: 'basic-layouts' })}>
+        <Link href="/Examples/basic-layouts/left-align" onClick={() => captureExampleClick('left-align', 'basic-layouts')}>
           <div className='summary-item'>
             <div className='image-container'>![basic-layouts-left-align](../../../app/app/demos/basic-layouts/left-align/preview.png)</div>
             <div className='label-container'>
@@ -87,7 +93,7 @@ import posthog from "posthog-js";
 
 <Cards num={2}>
   
-        <Link href="/Examples/utils/pagination" onClick={() => posthog.capture('example-clicked', { name: 'pagination', kind: 'utils' })}>
+        <Link href="/Examples/utils/pagination" onClick={() => captureExampleClick('pagination', 'utils')}>
           <div className='summary-item'>
             <div className='image-container'>![utils-pagination](../../../app/app/demos/utils/pagination/preview.png)</div>
             <div className='label-container'>
@@ -102,7 +108,7 @@ import posthog from "posthog-js";
 
 <Cards num={2}>
   
-        <Link href="/Examples/custom-animations/tinder" onClick={() => posthog.capture('example-clicked', { name: 'tinder', kind: 'custom-animations' })}>
+        <Link href="/Examples/custom-animations/tinder" onClick={() => captureExampleClick('tinder', 'custom-animations')}>
           <div className='summary-item'>
             <div className='image-container'>![custom-animations-tinder](../../../app/app/demos/custom-animations/tinder/preview.png)</div>
             <div className='label-container'>
@@ -112,7 +118,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/custom-animations/scale-fade-in-out" onClick={() => posthog.capture('example-clicked', { name: 'scale-fade-in-out', kind: 'custom-animations' })}>
+        <Link href="/Examples/custom-animations/scale-fade-in-out" onClick={() => captureExampleClick('scale-fade-in-out', 'custom-animations')}>
           <div className='summary-item'>
             <div className='image-container'>![custom-animations-scale-fade-in-out](../../../app/app/demos/custom-animations/scale-fade-in-out/preview.png)</div>
             <div className='label-container'>
@@ -122,7 +128,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/custom-animations/rotate-in-out" onClick={() => posthog.capture('example-clicked', { name: 'rotate-in-out', kind: 'custom-animations' })}>
+        <Link href="/Examples/custom-animations/rotate-in-out" onClick={() => captureExampleClick('rotate-in-out', 'custom-animations')}>
           <div className='summary-item'>
             <div className='image-container'>![custom-animations-rotate-in-out](../../../app/app/demos/custom-animations/rotate-in-out/preview.png)</div>
             <div className='label-container'>
@@ -132,7 +138,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/custom-animations/rotate-fade-in-out" onClick={() => posthog.capture('example-clicked', { name: 'rotate-fade-in-out', kind: 'custom-animations' })}>
+        <Link href="/Examples/custom-animations/rotate-fade-in-out" onClick={() => captureExampleClick('rotate-fade-in-out', 'custom-animations')}>
           <div className='summary-item'>
             <div className='image-container'>![custom-animations-rotate-fade-in-out](../../../app/app/demos/custom-animations/rotate-fade-in-out/preview.png)</div>
             <div className='label-container'>
@@ -142,7 +148,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/custom-animations/quick-swipe" onClick={() => posthog.capture('example-clicked', { name: 'quick-swipe', kind: 'custom-animations' })}>
+        <Link href="/Examples/custom-animations/quick-swipe" onClick={() => captureExampleClick('quick-swipe', 'custom-animations')}>
           <div className='summary-item'>
             <div className='image-container'>![custom-animations-quick-swipe](../../../app/app/demos/custom-animations/quick-swipe/preview.png)</div>
             <div className='label-container'>
@@ -152,7 +158,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/custom-animations/press-swipe" onClick={() => posthog.capture('example-clicked', { name: 'press-swipe', kind: 'custom-animations' })}>
+        <Link href="/Examples/custom-animations/press-swipe" onClick={() => captureExampleClick('press-swipe', 'custom-animations')}>
           <div className='summary-item'>
             <div className='image-container'>![custom-animations-press-swipe](../../../app/app/demos/custom-animations/press-swipe/preview.png)</div>
             <div className='label-container'>
@@ -162,7 +168,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/custom-animations/multiple" onClick={() => posthog.capture('example-clicked', { name: 'multiple', kind: 'custom-animations' })}>
+        <Link href="/Examples/custom-animations/multiple" onClick={() => captureExampleClick('multiple', 'custom-animations')}>
           <div className='summary-item'>
             <div className='image-container'>![custom-animations-multiple](../../../app/app/demos/custom-animations/multiple/preview.png)</div>
             <div className='label-container'>
@@ -172,7 +178,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/custom-animations/fold" onClick={() => posthog.capture('example-clicked', { name: 'fold', kind: 'custom-animations' })}>
+        <Link href="/Examples/custom-animations/fold" onClick={() => captureExampleClick('fold', 'custom-animations')}>
           <div className='summary-item'>
             <div className='image-container'>![custom-animations-fold](../../../app/app/demos/custom-animations/fold/preview.png)</div>
             <div className='label-container'>
@@ -182,7 +188,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/custom-animations/flow" onClick={() => posthog.capture('example-clicked', { name: 'flow', kind: 'custom-animations' })}>
+        <Link href="/Examples/custom-animations/flow" onClick={() => captureExampleClick('flow', 'custom-animations')}>
           <div className='summary-item'>
             <div className='image-container'>![custom-animations-flow](../../../app/app/demos/custom-animations/flow/preview.png)</div>
             <div className='label-container'>
@@ -192,7 +198,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/custom-animations/curve" onClick={() => posthog.capture('example-clicked', { name: 'curve', kind: 'custom-animations' })}>
+        <Link href="/Examples/custom-animations/curve" onClick={() => captureExampleClick('curve', 'custom-animations')}>
           <div className='summary-item'>
             <div className='image-container'>![custom-animations-curve](../../../app/app/demos/custom-animations/curve/preview.png)</div>
             <div className='label-container'>
@@ -202,7 +208,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/custom-animations/cube-3d" onClick={() => posthog.capture('example-clicked', { name: 'cube-3d', kind: 'custom-animations' })}>
+        <Link href="/Examples/custom-animations/cube-3d" onClick={() => captureExampleClick('cube-3d', 'custom-animations')}>
           <div className='summary-item'>
             <div className='image-container'>![custom-animations-cube-3d](../../../app/app/demos/custom-animations/cube-3d/preview.png)</div>
             <div className='label-container'>
@@ -212,7 +218,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/custom-animations/circular" onClick={() => posthog.capture('example-clicked', { name: 'circular', kind: 'custom-animations' })}>
+        <Link href="/Examples/custom-animations/circular" onClick={() => captureExampleClick('circular', 'custom-animations')}>
           <div className='summary-item'>
             <div className='image-container'>![custom-animations-circular](../../../app/app/demos/custom-animations/circular/preview.png)</div>
             <div className='label-container'>
@@ -222,7 +228,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/custom-animations/blur-rotate" onClick={() => posthog.capture('example-clicked', { name: 'blur-rotate', kind: 'custom-animations' })}>
+        <Link href="/Examples/custom-animations/blur-rotate" onClick={() => captureExampleClick('blur-rotate', 'custom-animations')}>
           <div className='summary-item'>
             <div className='image-container'>![custom-animations-blur-rotate](../../../app/app/demos/custom-animations/blur-rotate/preview.png)</div>
             <div className='label-container'>
@@ -232,7 +238,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/custom-animations/blur-parallax" onClick={() => posthog.capture('example-clicked', { name: 'blur-parallax', kind: 'custom-animations' })}>
+        <Link href="/Examples/custom-animations/blur-parallax" onClick={() => captureExampleClick('blur-parallax', 'custom-animations')}>
           <div className='summary-item'>
             <div className='image-container'>![custom-animations-blur-parallax](../../../app/app/demos/custom-animations/blur-parallax/preview.png)</div>
             <div className='label-container'>
@@ -242,7 +248,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/custom-animations/anim-tab-bar" onClick={() => posthog.capture('example-clicked', { name: 'anim-tab-bar', kind: 'custom-animations' })}>
+        <Link href="/Examples/custom-animations/anim-tab-bar" onClick={() => captureExampleClick('anim-tab-bar', 'custom-animations')}>
           <div className='summary-item'>
             <div className='image-container'>![custom-animations-anim-tab-bar](../../../app/app/demos/custom-animations/anim-tab-bar/preview.png)</div>
             <div className='label-container'>
@@ -252,7 +258,7 @@ import posthog from "posthog-js";
         </Link>
   
 
-        <Link href="/Examples/custom-animations/advanced-parallax" onClick={() => posthog.capture('example-clicked', { name: 'advanced-parallax', kind: 'custom-animations' })}>
+        <Link href="/Examples/custom-animations/advanced-parallax" onClick={() => captureExampleClick('advanced-parallax', 'custom-animations')}>
           <div className='summary-item'>
             <div className='image-container'>![custom-animations-advanced-parallax](../../../app/app/demos/custom-animations/advanced-parallax/preview.png)</div>
             <div className='label-container'>

--- a/example/website/pages/_app.js
+++ b/example/website/pages/_app.js
@@ -3,9 +3,11 @@ import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
 import Script from "next/script";
 
-if (typeof window !== "undefined") {
+const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+if (typeof window !== "undefined" && posthogKey) {
   // checks that we are client-side
-  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+  posthog.init(posthogKey, {
     api_host:
       process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com",
     person_profiles: "identified_only", // or 'always' to create profiles for anonymous users as well
@@ -19,6 +21,8 @@ export default function MyApp({
   Component,
   pageProps: { session: _session, ...pageProps },
 }) {
+  const page = <Component {...pageProps} />;
+
   return (
     <>
       {/* Google AdSense Script */}
@@ -29,9 +33,7 @@ export default function MyApp({
         strategy="afterInteractive"
       />
       
-      <PostHogProvider client={posthog}>
-        <Component {...pageProps} />
-      </PostHogProvider>
+      {posthogKey ? <PostHogProvider client={posthog}>{page}</PostHogProvider> : page}
     </>
   );
 }

--- a/example/website/pages/custom-animations.mdx
+++ b/example/website/pages/custom-animations.mdx
@@ -26,15 +26,24 @@ slug: /custom-animations
 import { Callout } from 'nextra/components'
 
 
-After some effort, we finally implemented custom animation in v2, now we just need to implement a callback function of type `TAnimationStyle` and pass it to the `customAnimation` property of `Carousel`.
+Pass a worklet-compatible callback of type `TAnimationStyle` to the `customAnimation` prop.
 
 ### Prepare
 
-```
-type TAnimationStyle = (value: number) => ViewStyle;
+```ts
+import type { TAnimationStyle } from "react-native-reanimated-carousel";
+
+const animationStyle: TAnimationStyle = (value, _index) => {
+  "worklet";
+
+  return {
+    opacity: Math.max(0, 1 - Math.abs(value)),
+    zIndex: Math.round(100 - Math.abs(value)),
+  };
+};
 ```
 
-This function will be called in each item and accepts a parameter `value` indicating the position of the current item relative to `window`. The following picture shows the relationship between `value` and position
+The callback receives `value`, the item's animated position relative to the viewport, and `index`, the item's data index. The following picture shows the relationship between `value` and position.
 
 ![Sketch File](../../../assets/custom-animation-sketch.png)
 
@@ -50,7 +59,7 @@ Here are a few examples.
 
 #### Parallax
 
-<a href="https://github.com/dohooo/react-native-reanimated-carousel/blob/main/example/app/src/pages/advanced-parallax/index.tsx">
+<a href="https://github.com/dohooo/react-native-reanimated-carousel/blob/main/example/app/app/demos/custom-animations/advanced-parallax/demo.tsx">
     ![advanced-parallax](../../../assets/advanced-parallax.gif)
 </a>
 
@@ -124,7 +133,7 @@ In order to implement some animation effects outside `Carousel`, such as `MaskVi
 
 #### ScaleFadeInOut
 
-<a href="https://github.com/dohooo/react-native-reanimated-carousel/blob/main/example/app/src/pages/scale-fade-in-out/index.tsx">
+<a href="https://github.com/dohooo/react-native-reanimated-carousel/blob/main/example/app/app/demos/custom-animations/scale-fade-in-out/demo.tsx">
     ![scale-fade-in-out](../../../assets/scale-fade-in-out.gif)
 </a>
 

--- a/example/website/pages/faq.mdx
+++ b/example/website/pages/faq.mdx
@@ -29,7 +29,7 @@ When rendering a large number of elements, you can use the 'windowSize' property
 
 ## Used in `ScrollView/FlatList`
 
-**[#143](https://github.com/dohooo/react-native-reanimated-carousel/issues/143) - Carousel suppresses ScrollView/FlatList scroll gesture handler:** When a horizontal carousel is nested in a vertical `ScrollView` or `FlatList`, configure the pan gesture so small horizontal movement does not capture the parent scroll. For example, use Gesture Handler's [`activeOffsetX`](https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture/#activeoffsetx):
+**[#143](https://github.com/dohooo/react-native-reanimated-carousel/issues/143) - Carousel suppresses ScrollView/FlatList scroll gesture handler:** When a horizontal carousel is nested in a vertical `ScrollView` or `FlatList`, configure the pan gesture so small horizontal movement does not capture the parent scroll. For example, use Gesture Handler's [`activeOffsetX`](https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture/):
 
 ```tsx copy
 <Carousel

--- a/example/website/pages/index.mdx
+++ b/example/website/pages/index.mdx
@@ -69,10 +69,45 @@ yarn add react-native-reanimated-carousel@beta react-native-reanimated react-nat
 ```
 
 <Callout type="warning" emoji="⚠️">
-**React Native Gesture Handler** needs extra steps to finalize its installation, please follow their [installation instructions](https://docs.swmansion.com/react-native-gesture-handler/docs/installation). Please **make sure** to wrap your App with `GestureHandlerRootView` when you've upgraded to React Native Gesture Handler ^2.
+**React Native Gesture Handler** needs extra steps to finalize its installation, please follow their [installation instructions](https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation). Please **make sure** to wrap your App with `GestureHandlerRootView` when you've upgraded to React Native Gesture Handler ^2.
 
 **React Native Reanimated 4** requires a compatible `react-native-worklets` version. Follow the [Reanimated installation guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started) and [compatibility table](https://docs.swmansion.com/react-native-reanimated/docs/guides/compatibility). Community CLI projects must use the `react-native-worklets/plugin` Babel plugin as documented there.
 </Callout>
+
+## Your first carousel
+
+Once the native dependencies are configured, this is a complete minimal example:
+
+```tsx
+import * as React from "react";
+import { Text, useWindowDimensions, View } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import Carousel from "react-native-reanimated-carousel";
+
+const data = ["First", "Second", "Third"];
+
+export default function App() {
+  const { width } = useWindowDimensions();
+
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <View style={{ flex: 1, justifyContent: "center" }}>
+        <Carousel
+          style={{ width, height: 200 }}
+          data={data}
+          renderItem={({ item }) => (
+            <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+              <Text>{item}</Text>
+            </View>
+          )}
+        />
+      </View>
+    </GestureHandlerRootView>
+  );
+}
+```
+
+Continue with [Usage](/usage) for sizing and pagination, or open the full [Props reference](/props).
 
 
 ## Special thanks
@@ -91,7 +126,7 @@ yarn add react-native-reanimated-carousel@beta react-native-reanimated react-nat
 To keep this library maintained and up-to-date please consider sponsoring to us. ☕️
 
 - [Caspian](https://github.com/sponsors/dohooo) 
-- [GX](https://github.com/gxxgcn)
+- GX
 - [Oliver Lopez](https://github.com/sponsors/oliverloops) 
 
 <p align="center">

--- a/example/website/public/sitemap-0.xml
+++ b/example/website/public/sitemap-0.xml
@@ -28,6 +28,8 @@
 <url><loc>https://rn-carousel.dev/custom-animations</loc><lastmod>2025-07-08T03:37:06.931Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://rn-carousel.dev/faq</loc><lastmod>2025-07-08T03:37:06.931Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://rn-carousel.dev/migration-v4</loc><lastmod>2025-07-08T03:37:06.931Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://rn-carousel.dev/migration-v5</loc><lastmod>2025-07-08T03:37:06.931Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://rn-carousel.dev/programmatic-control</loc><lastmod>2025-07-08T03:37:06.931Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://rn-carousel.dev/props</loc><lastmod>2025-07-08T03:37:06.931Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://rn-carousel.dev/usage</loc><lastmod>2025-07-08T03:37:06.931Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/example/website/scripts/gen-summary-template.mjs
+++ b/example/website/scripts/gen-summary-template.mjs
@@ -49,6 +49,12 @@ import { Cards } from 'nextra/components'
 import Link from 'next/link'
 import posthog from "posthog-js";
 
+export const captureExampleClick = (name, kind) => {
+  if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+    posthog.capture('example-clicked', { name, kind });
+  }
+};
+
 ${Object.keys(groupedPages)
   .sort((a, b) => {
     const kindsSort = ["basic-layouts", "utils", "custom-animations"];
@@ -69,7 +75,7 @@ ${Object.keys(groupedPages)
     .map((page) => {
       const { pageKind, pageName } = page.demo;
       return `
-        <Link href="/Examples/${pageKind}/${pageName}" onClick={() => posthog.capture('example-clicked', { name: '${pageName}', kind: '${pageKind}' })}>
+        <Link href="/Examples/${pageKind}/${pageName}" onClick={() => captureExampleClick('${pageName}', '${pageKind}')}>
           <div className='summary-item'>
             <div className='image-container'>![${pageKind}-${pageName}](../../../app/app/demos/${pageKind}/${pageName}/preview.png)</div>
             <div className='label-container'>

--- a/example/website/theme.config.tsx
+++ b/example/website/theme.config.tsx
@@ -13,9 +13,10 @@ const config: DocsThemeConfig = {
   chat: {
     link: "https://discord.gg/qB9h3kGNas",
   },
-  docsRepositoryBase: "https://github.com/dohooo/react-native-reanimated-carousel",
+  docsRepositoryBase:
+    "https://github.com/dohooo/react-native-reanimated-carousel/tree/main/example/website",
   footer: {
-    text: "Copyright © 2024 Caspian. Built with Nextra.",
+    text: `Copyright © ${new Date().getFullYear()} Caspian. Built with Nextra.`,
   },
   sidebar: {
     defaultMenuCollapseLevel: 1,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
 	"source": "src/index",
 	"files": [
 		"lib",
-		"src"
+		"src",
+		"!src/**/*.test.ts",
+		"!src/**/*.test.tsx"
 	],
 	"scripts": {
 		"gif": "node scripts/makegif.js ./scripts/gif-works-directory",


### PR DESCRIPTION
## Summary

- add a complete v5 beta quick start and refresh stale docs, links, badges, and contributor templates
- fix the stack example to use the v5 style sizing path and guard optional PostHog analytics
- exclude test files from the npm tarball while preserving all runtime source and build entry points

## Verification

- `yarn format`
- `yarn lint`
- `yarn types`
- `yarn test --runInBand` (357 tests)
- `yarn prepare`
- `yarn changeset:check`
- `yarn --cwd example/app types`
- `yarn --cwd example/app build:web` (51 routes)
- `yarn --cwd example/website build` (34 pages)
- `yarn web:smoke` (2 Chromium tests)
- `yarn compat:expo 54` (packed consumer, web export, Android `assembleDebug`)
- local docs crawl (194 links, 0 broken; GitHub repository paths verified separately)
