### PR TITLE
fix: align changeset summaries with generated changelog

### DIFF
--- a/.changeset/blue-news-stare.md
+++ b/.changeset/blue-news-stare.md
@@ -2,5 +2,5 @@
 "react-native-reanimated-carousel": minor
 ---
 
-- Add `itemWidth`/`itemHeight` to define snap step explicitly (for example, multi-card pages) (PR #853).
+Add `itemWidth`/`itemHeight` to define snap step explicitly (for example, multi-card pages) (PR #853).
 - Keep backward compatibility by falling back to container size or legacy `width`/`height` (PR #853).

--- a/.changeset/clean-package-tests.md
+++ b/.changeset/clean-package-tests.md
@@ -2,4 +2,4 @@
 "react-native-reanimated-carousel": patch
 ---
 
-- Exclude test files from published package tarballs while keeping the React Native source entry intact.
+Exclude test files from published package tarballs while keeping the React Native source entry intact.

--- a/.changeset/fix-container-size-warning.md
+++ b/.changeset/fix-container-size-warning.md
@@ -2,4 +2,4 @@
 "react-native-reanimated-carousel": patch
 ---
 
-- Recognize percentage and flex container styles in development sizing warnings.
+Recognize percentage and flex container styles in development sizing warnings.

--- a/.changeset/fix-flex-gesture-blocking.md
+++ b/.changeset/fix-flex-gesture-blocking.md
@@ -2,5 +2,5 @@
 "react-native-reanimated-carousel": patch
 ---
 
-- Fix gesture blocking with `style={{ flex: 1 }}` by reading `resolvedSize.value` on the UI thread (PR #878).
+Fix gesture blocking with `style={{ flex: 1 }}` by reading `resolvedSize.value` on the UI thread (PR #878).
 - Fix `itemWidth`/`itemHeight` precedence over `style.width` in `ItemLayout` (PR #878).

--- a/.changeset/fix-loop-window-visible-ranges.md
+++ b/.changeset/fix-loop-window-visible-ranges.md
@@ -2,5 +2,5 @@
 "react-native-reanimated-carousel": patch
 ---
 
-- Keep every item rendered in loop mode when `windowSize` is equal to or greater than the data length (Issue #918).
+Keep every item rendered in loop mode when `windowSize` is equal to or greater than the data length (Issue #918).
 - Add unit and Maestro regression coverage for small looped data sets.

--- a/.changeset/fix-nested-gesture-root.md
+++ b/.changeset/fix-nested-gesture-root.md
@@ -2,5 +2,5 @@
 "react-native-reanimated-carousel": patch
 ---
 
-- Remove the nested `GestureHandlerRootView` so correctly configured apps no longer log the Android parent-root warning (Issue #921).
+Remove the nested `GestureHandlerRootView` so correctly configured apps no longer log the Android parent-root warning (Issue #921).
 - Preserve carousel navigation and gestures by relying on the application-level Gesture Handler root required during installation.

--- a/.changeset/fix-nonloop-overdrag-visible-ranges.md
+++ b/.changeset/fix-nonloop-overdrag-visible-ranges.md
@@ -2,5 +2,5 @@
 "react-native-reanimated-carousel": patch
 ---
 
-- Clamp visible ranges during non-loop overdrag so the first item stays visible when dragging right at page start (PR #872).
+Clamp visible ranges during non-loop overdrag so the first item stays visible when dragging right at page start (PR #872).
 - Add regression test coverage for non-loop overdrag boundary behavior (PR #872).

--- a/.changeset/fix-nonloop-overscroll.md
+++ b/.changeset/fix-nonloop-overscroll.md
@@ -2,5 +2,5 @@
 "react-native-reanimated-carousel": patch
 ---
 
-- Fix non-loop overscroll direction so tiny positive offsets at the first page no longer wrap to the last page (PR #871).
+Fix non-loop overscroll direction so tiny positive offsets at the first page no longer wrap to the last page (PR #871).
 - Add integration tests for `next()` and `scrollTo()` boundary behavior (PR #871).

--- a/.changeset/fix-nonloop-scrollto-offset-regression.md
+++ b/.changeset/fix-nonloop-scrollto-offset-regression.md
@@ -2,5 +2,5 @@
 "react-native-reanimated-carousel": patch
 ---
 
-- Fix non-loop `scrollTo()` so backward jumps keep the correct negative offset instead of briefly rendering a blank frame.
+Fix non-loop `scrollTo()` so backward jumps keep the correct negative offset instead of briefly rendering a blank frame.
 - Add regression tests for non-loop backward `scrollTo()` and returning to index `0`.

--- a/.changeset/fix-pagination-accessibility.md
+++ b/.changeset/fix-pagination-accessibility.md
@@ -2,5 +2,5 @@
 "react-native-reanimated-carousel": patch
 ---
 
-- Fix pagination selected-state syncing via `scheduleOnRN` instead of render-time reads from reanimated values (PR #866).
+Fix pagination selected-state syncing via `scheduleOnRN` instead of render-time reads from reanimated values (PR #866).
 - Add tests to prevent accessibility regressions and warning noise (PR #866).

--- a/.changeset/fix-progress-shared-dependencies.md
+++ b/.changeset/fix-progress-shared-dependencies.md
@@ -2,4 +2,4 @@
 "react-native-reanimated-carousel": patch
 ---
 
-- Refresh progress reactions when the offset or size-readiness shared value instance changes (Issue #923).
+Refresh progress reactions when the offset or size-readiness shared value instance changes (Issue #923).

--- a/.changeset/fix-react-19-web-ref-warning.md
+++ b/.changeset/fix-react-19-web-ref-warning.md
@@ -2,5 +2,5 @@
 "react-native-reanimated-carousel": patch
 ---
 
-- Avoid the React 19 `element.ref` warning on web by removing the internal gesture child ref (Issue #857).
+Avoid the React 19 `element.ref` warning on web by removing the internal gesture child ref (Issue #857).
 - Preserve horizontal and vertical non-loop boundaries with layout-derived container dimensions.

--- a/.changeset/fix-responsive-auto-size.md
+++ b/.changeset/fix-responsive-auto-size.md
@@ -2,5 +2,5 @@
 "react-native-reanimated-carousel": patch
 ---
 
-- Keep automatically measured carousels responsive when their window or parent container changes size (Issue #890).
+Keep automatically measured carousels responsive when their window or parent container changes size (Issue #890).
 - Preserve explicit style, item size, and legacy `width`/`height` sizing behavior.

--- a/.changeset/fix-reverse-loop-initial-range.md
+++ b/.changeset/fix-reverse-loop-initial-range.md
@@ -2,4 +2,4 @@
 "react-native-reanimated-carousel": patch
 ---
 
-- Mount the reverse visible range on the first render so looped parallax items preserve their styles and props when swiping backward (Issue #899).
+Mount the reverse visible range on the first render so looped parallax items preserve their styles and props when swiping backward (Issue #899).

--- a/.changeset/fix-second-tier-tdd-issues.md
+++ b/.changeset/fix-second-tier-tdd-issues.md
@@ -2,5 +2,5 @@
 "react-native-reanimated-carousel": patch
 ---
 
-- Fix non-loop clamping, invalid-size visible-range fallback, pagination accessibility defaults, and `customAnimation` style sanitization (PR #883).
+Fix non-loop clamping, invalid-size visible-range fallback, pagination accessibility defaults, and `customAnimation` style sanitization (PR #883).
 - Add focused regression tests for clamping, visibility fallback, accessibility labels, and animation style normalization (PR #883).

--- a/.changeset/fix-web-worklets-error.md
+++ b/.changeset/fix-web-worklets-error.md
@@ -2,4 +2,4 @@
 "react-native-reanimated-carousel": patch
 ---
 
-- Upgrade `react-native-worklets` from `0.5.1` to `0.5.2` to fix web docs crash in JSWorklets serialization (PR #875).
+Upgrade `react-native-worklets` from `0.5.1` to `0.5.2` to fix web docs crash in JSWorklets serialization (PR #875).

--- a/.changeset/honest-baboons-sip.md
+++ b/.changeset/honest-baboons-sip.md
@@ -2,6 +2,6 @@
 "react-native-reanimated-carousel": major
 ---
 
-- Add v5 support for Expo 54 and dynamic sizing with optional `width`/`height` and layout-based measurement (PR #850).
+Add v5 support for Expo 54 and dynamic sizing with optional `width`/`height` and layout-based measurement (PR #850).
 - Upgrade peer requirements to `react-native-reanimated >=4.1.0`, `react-native-worklets >=0.5.0`, and `react-native-gesture-handler >=2.9.0` (PR #850).
 - Replace deprecated `runOnJS` usage with `scheduleOnRN`, plus expanded tests and migration docs for v4 to v5 (PR #850).

--- a/.changeset/odd-news-carry.md
+++ b/.changeset/odd-news-carry.md
@@ -2,6 +2,6 @@
 "react-native-reanimated-carousel": minor
 ---
 
-- Refresh style API so `style` controls outer container sizing/positioning (PR #853).
+Refresh style API so `style` controls outer container sizing/positioning (PR #853).
 - Replace `containerStyle` with `contentContainerStyle` for scroll content styling (PR #853).
 - Deprecate `width` and `height` props in favor of style-based sizing while keeping backward compatibility (PR #853).

--- a/.changeset/require-reanimated-4-1.md
+++ b/.changeset/require-reanimated-4-1.md
@@ -2,4 +2,4 @@
 "react-native-reanimated-carousel": patch
 ---
 
-- Require React Native Reanimated 4.1 or newer to avoid incompatible Reanimated 4.0 and React Native Worklets 0.5 combinations.
+Require React Native Reanimated 4.1 or newer to avoid incompatible Reanimated 4.0 and React Native Worklets 0.5 combinations.

--- a/.changeset/style-based-sizing.md
+++ b/.changeset/style-based-sizing.md
@@ -2,7 +2,7 @@
 "react-native-reanimated-carousel": minor
 ---
 
-- Deprecate `width` and `height`; prefer `style={{ width, height }}` sizing (PR #873).
+Deprecate `width` and `height`; prefer `style={{ width, height }}` sizing (PR #873).
 - Deprecate `defaultScrollOffsetValue`; prefer `scrollOffsetValue` (PR #873).
 - Prioritize `style` dimensions when both new and legacy props are provided (PR #873).
 - Keep legacy props functional in v5 with migration warnings (PR #873).

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -11,7 +11,7 @@ Use this skill to generate release-ready changeset entries in the repository sty
 
 - Review current branch changes.
 - Propose release impact (major/minor/patch) from code diffs.
-- Draft concise changeset bullets.
+- Draft concise Changesets-compatible summaries.
 - Preview and ask for explicit user confirmation.
 - Create or update `.changeset/*.md` only after confirmation.
 
@@ -19,8 +19,8 @@ Use this skill to generate release-ready changeset entries in the repository sty
 
 Follow `docs/changeset-style.md` strictly:
 
-1. Bullet-only summary lines (`- ...`).
-2. 1-6 bullets, each concise and user-facing.
+1. Start with one plain summary sentence without a list marker.
+2. Add up to five optional follow-up bullets (`- ...`); keep every line concise and user-facing.
 3. No headings, code blocks, root-cause sections, or file lists.
 4. Keep implementation detail in PR discussion/docs, not release notes.
 
@@ -92,7 +92,7 @@ When previewing, always include:
 2. `Confidence:`
 3. `Why:`
 4. `Alternative bump options:`
-5. `Draft changeset:` fenced markdown block
+5. `Draft changeset:` fenced markdown block using a plain first summary line
 6. `Confirmation prompt`
 
 Never write or modify `.changeset/*.md` before explicit `confirm`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,9 @@ jobs:
         run: yarn types
 
       - name: Check changeset style
-        run: yarn changeset:check
+        run: |
+          node --test scripts/check-changeset-style.test.mjs
+          yarn changeset:check
 
   build-and-test:
     name: Build & Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,35 +4,35 @@
 
 ### Patch Changes
 
-- [#927](https://github.com/dohooo/react-native-reanimated-carousel/pull/927) [`0763d35`](https://github.com/dohooo/react-native-reanimated-carousel/commit/0763d35aae00e4b9f4ad04dd71d8b250db3b6dfc) Thanks [@dohooo](https://github.com/dohooo)! - - Recognize percentage and flex container styles in development sizing warnings.
+- [#927](https://github.com/dohooo/react-native-reanimated-carousel/pull/927) [`0763d35`](https://github.com/dohooo/react-native-reanimated-carousel/commit/0763d35aae00e4b9f4ad04dd71d8b250db3b6dfc) Thanks [@dohooo](https://github.com/dohooo)! - Recognize percentage and flex container styles in development sizing warnings.
 
-- [#926](https://github.com/dohooo/react-native-reanimated-carousel/pull/926) [`578a4be`](https://github.com/dohooo/react-native-reanimated-carousel/commit/578a4be46ddeb0bd9100b5568bb7144ca19fc72b) Thanks [@dohooo](https://github.com/dohooo)! - - Refresh progress reactions when the offset or size-readiness shared value instance changes (Issue #923).
+- [#926](https://github.com/dohooo/react-native-reanimated-carousel/pull/926) [`578a4be`](https://github.com/dohooo/react-native-reanimated-carousel/commit/578a4be46ddeb0bd9100b5568bb7144ca19fc72b) Thanks [@dohooo](https://github.com/dohooo)! - Refresh progress reactions when the offset or size-readiness shared value instance changes (Issue #923).
 
-- [#911](https://github.com/dohooo/react-native-reanimated-carousel/pull/911) [`da3b11b`](https://github.com/dohooo/react-native-reanimated-carousel/commit/da3b11bd6664a91994287cc0644ff6a4cfb837cb) Thanks [@dohooo](https://github.com/dohooo)! - - Avoid the React 19 `element.ref` warning on web by removing the internal gesture child ref (Issue #857).
+- [#911](https://github.com/dohooo/react-native-reanimated-carousel/pull/911) [`da3b11b`](https://github.com/dohooo/react-native-reanimated-carousel/commit/da3b11bd6664a91994287cc0644ff6a4cfb837cb) Thanks [@dohooo](https://github.com/dohooo)! - Avoid the React 19 `element.ref` warning on web by removing the internal gesture child ref (Issue #857).
 
   - Preserve horizontal and vertical non-loop boundaries with layout-derived container dimensions.
 
-- [#913](https://github.com/dohooo/react-native-reanimated-carousel/pull/913) [`b68c803`](https://github.com/dohooo/react-native-reanimated-carousel/commit/b68c80329c60a51ff58cf9363ea98ac244bc56bf) Thanks [@dohooo](https://github.com/dohooo)! - - Mount the reverse visible range on the first render so looped parallax items preserve their styles and props when swiping backward (Issue #899).
+- [#913](https://github.com/dohooo/react-native-reanimated-carousel/pull/913) [`b68c803`](https://github.com/dohooo/react-native-reanimated-carousel/commit/b68c80329c60a51ff58cf9363ea98ac244bc56bf) Thanks [@dohooo](https://github.com/dohooo)! - Mount the reverse visible range on the first render so looped parallax items preserve their styles and props when swiping backward (Issue #899).
 
 ## 5.0.0-beta.6
 
 ### Patch Changes
 
-- [#924](https://github.com/dohooo/react-native-reanimated-carousel/pull/924) [`e4fa56f`](https://github.com/dohooo/react-native-reanimated-carousel/commit/e4fa56f6160eb22cfb1f46bf314eadc29f0c74f3) Thanks [@dohooo](https://github.com/dohooo)! - - Keep every item rendered in loop mode when `windowSize` is equal to or greater than the data length (Issue #918).
+- [#924](https://github.com/dohooo/react-native-reanimated-carousel/pull/924) [`e4fa56f`](https://github.com/dohooo/react-native-reanimated-carousel/commit/e4fa56f6160eb22cfb1f46bf314eadc29f0c74f3) Thanks [@dohooo](https://github.com/dohooo)! - Keep every item rendered in loop mode when `windowSize` is equal to or greater than the data length (Issue #918).
 
   - Add unit and Maestro regression coverage for small looped data sets.
 
-- [#924](https://github.com/dohooo/react-native-reanimated-carousel/pull/924) [`e4fa56f`](https://github.com/dohooo/react-native-reanimated-carousel/commit/e4fa56f6160eb22cfb1f46bf314eadc29f0c74f3) Thanks [@dohooo](https://github.com/dohooo)! - - Keep automatically measured carousels responsive when their window or parent container changes size (Issue #890).
+- [#924](https://github.com/dohooo/react-native-reanimated-carousel/pull/924) [`e4fa56f`](https://github.com/dohooo/react-native-reanimated-carousel/commit/e4fa56f6160eb22cfb1f46bf314eadc29f0c74f3) Thanks [@dohooo](https://github.com/dohooo)! - Keep automatically measured carousels responsive when their window or parent container changes size (Issue #890).
 
   - Preserve explicit style, item size, and legacy `width`/`height` sizing behavior.
 
-- [#924](https://github.com/dohooo/react-native-reanimated-carousel/pull/924) [`e4fa56f`](https://github.com/dohooo/react-native-reanimated-carousel/commit/e4fa56f6160eb22cfb1f46bf314eadc29f0c74f3) Thanks [@dohooo](https://github.com/dohooo)! - - Require React Native Reanimated 4.1 or newer to avoid incompatible Reanimated 4.0 and React Native Worklets 0.5 combinations.
+- [#924](https://github.com/dohooo/react-native-reanimated-carousel/pull/924) [`e4fa56f`](https://github.com/dohooo/react-native-reanimated-carousel/commit/e4fa56f6160eb22cfb1f46bf314eadc29f0c74f3) Thanks [@dohooo](https://github.com/dohooo)! - Require React Native Reanimated 4.1 or newer to avoid incompatible Reanimated 4.0 and React Native Worklets 0.5 combinations.
 
 ## 5.0.0-beta.5
 
 ### Patch Changes
 
-- [#891](https://github.com/dohooo/react-native-reanimated-carousel/pull/891) [`73d066d`](https://github.com/dohooo/react-native-reanimated-carousel/commit/73d066dae6595b918c1bcf30c76bc40a7e27a6ad) Thanks [@notsuhas](https://github.com/notsuhas)! - - Fix non-loop `scrollTo()` so backward jumps keep the correct negative offset instead of briefly rendering a blank frame.
+- [#891](https://github.com/dohooo/react-native-reanimated-carousel/pull/891) [`73d066d`](https://github.com/dohooo/react-native-reanimated-carousel/commit/73d066dae6595b918c1bcf30c76bc40a7e27a6ad) Thanks [@notsuhas](https://github.com/notsuhas)! - Fix non-loop `scrollTo()` so backward jumps keep the correct negative offset instead of briefly rendering a blank frame.
   - Add regression tests for non-loop backward `scrollTo()` and returning to index `0`.
 
 ## 5.0.0-beta.4
@@ -131,7 +131,7 @@
 
 ### Minor Changes
 
-- [#853](https://github.com/dohooo/react-native-reanimated-carousel/pull/853) [`c595958`](https://github.com/dohooo/react-native-reanimated-carousel/commit/c59595896381c36cc395f95b8631aee503cfd927) Thanks [@dohooo](https://github.com/dohooo)! - - add `itemWidth`/`itemHeight` props so horizontal and vertical carousels can define their snapping step explicitly (e.g. to show multiple cards per page)
+- [#853](https://github.com/dohooo/react-native-reanimated-carousel/pull/853) [`c595958`](https://github.com/dohooo/react-native-reanimated-carousel/commit/c59595896381c36cc395f95b8631aee503cfd927) Thanks [@dohooo](https://github.com/dohooo)! - add `itemWidth`/`itemHeight` props so horizontal and vertical carousels can define their snapping step explicitly (e.g. to show multiple cards per page)
 
   - default behaviour still falls back to the carousel container size or legacy `width`/`height` props
 

--- a/docs/changeset-style.md
+++ b/docs/changeset-style.md
@@ -4,22 +4,27 @@ Goal: keep GitHub Releases short, scannable, and user-facing.
 
 ## Rules for every changeset file
 
-1. Use bullet-only summaries after frontmatter.
-2. Keep each bullet to one concise sentence (max 160 chars).
-3. Keep total bullets per file at 1-6.
+1. Start with one plain summary sentence after frontmatter; do not prefix it with a list marker.
+2. Add optional follow-up details as `- ...` bullets.
+3. Keep every line concise (max 160 chars) and use at most 6 lines per file.
 4. Focus on user impact, not internal implementation details.
 5. Put deep analysis in PR description or docs, not release notes.
 
+This matches `@changesets/changelog-github`, which adds the top-level release bullet itself.
+
 ## Allowed
 
-- Fix gesture blocking when `style={{ flex: 1 }}` is used.
-- Deprecate `width`/`height` in favor of style-based sizing.
+```md
+Fix gesture blocking when `style={{ flex: 1 }}` is used.
+- Preserve explicit sizing behavior.
+```
 
 ## Not allowed
 
 - Root-cause sections (`Root Cause`, `Solution`, `Affected Files`).
 - Markdown headings (`#`, `##`) in summary body.
 - Code blocks in summary body.
+- A list marker on the first summary line, because it renders as `- - ...` in the changelog.
 
 ## Validation
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"e2e:comprehensive": "APP_ID=${APP_ID:-com.react-native-reanimated-carousel.example} maestro test e2e/",
 		"compat:expo": "bash scripts/test-packed-expo-consumer.sh",
 		"web:smoke": "playwright test --config=playwright.config.ts",
-		"changeset:check": "node scripts/check-changeset-style.mjs"
+		"changeset:check": "node --test scripts/check-changeset-style.test.mjs && node scripts/check-changeset-style.mjs"
 	},
 	"resolutions": {
 		"@babel/plugin-transform-block-scoping": "7.28.4"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"e2e:comprehensive": "APP_ID=${APP_ID:-com.react-native-reanimated-carousel.example} maestro test e2e/",
 		"compat:expo": "bash scripts/test-packed-expo-consumer.sh",
 		"web:smoke": "playwright test --config=playwright.config.ts",
-		"changeset:check": "node --test scripts/check-changeset-style.test.mjs && node scripts/check-changeset-style.mjs"
+		"changeset:check": "node scripts/check-changeset-style.mjs"
 	},
 	"resolutions": {
 		"@babel/plugin-transform-block-scoping": "7.28.4"

--- a/scripts/check-changeset-style.mjs
+++ b/scripts/check-changeset-style.mjs
@@ -2,6 +2,7 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const CHANGESET_DIR = path.join(process.cwd(), ".changeset");
 const IGNORED_FILES = new Set(["README.md", "config.json", "pre.json"]);
@@ -17,13 +18,13 @@ const FORBIDDEN_PATTERNS = [
   /\bmigration steps?\b/i,
 ];
 
-function getBody(content) {
+export function getBody(content) {
   const match = /^---\n[\s\S]*?\n---\n?/u.exec(content);
   if (!match) return null;
   return content.slice(match[0].length).trim();
 }
 
-function checkChangeset(content) {
+export function checkChangeset(content) {
   const errors = [];
   const body = getBody(content);
 
@@ -53,14 +54,23 @@ function checkChangeset(content) {
     errors.push(`too many summary lines (${lines.length}); max is ${MAX_LINES}`);
   }
 
-  let bulletCount = 0;
-  for (const line of lines) {
+  const [summary, ...details] = lines;
+  if (/^(?:[-*+]|\d+[.)])\s+/u.test(summary)) {
+    errors.push(`summary line must not start with a list marker: "${summary}"`);
+  }
+
+  if (summary.length > MAX_LINE_LENGTH) {
+    errors.push(
+      `summary line too long (${summary.length}); max is ${MAX_LINE_LENGTH}`
+    );
+  }
+
+  for (const line of details) {
     if (!line.startsWith("- ")) {
-      errors.push(`line must start with "- ": "${line}"`);
+      errors.push(`detail line must start with "- ": "${line}"`);
       continue;
     }
 
-    bulletCount += 1;
     const text = line.slice(2).trim();
     if (!text) {
       errors.push("contains empty bullet line");
@@ -70,10 +80,6 @@ function checkChangeset(content) {
     if (text.length > MAX_LINE_LENGTH) {
       errors.push(`bullet too long (${text.length}); max is ${MAX_LINE_LENGTH}`);
     }
-  }
-
-  if (bulletCount === 0) {
-    errors.push("must include at least one bullet line");
   }
 
   return errors;
@@ -116,4 +122,10 @@ async function main() {
   console.log(`Changeset style check passed for ${files.length} file(s).`);
 }
 
-main();
+const isDirectExecution =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (isDirectExecution) {
+  main();
+}

--- a/scripts/check-changeset-style.test.mjs
+++ b/scripts/check-changeset-style.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { checkChangeset } from "./check-changeset-style.mjs";
+
+const wrap = (body) => `---
+"react-native-reanimated-carousel": patch
+---
+
+${body}
+`;
+
+test("accepts a plain summary line", () => {
+  assert.deepEqual(checkChangeset(wrap("Fix carousel sizing.")), []);
+});
+
+test("accepts optional follow-up bullets", () => {
+  assert.deepEqual(
+    checkChangeset(
+      wrap("Fix carousel sizing.\n- Preserve explicit dimensions.")
+    ),
+    []
+  );
+});
+
+test("rejects a list marker on the summary line", () => {
+  assert.deepEqual(checkChangeset(wrap("- Fix carousel sizing.")), [
+    'summary line must not start with a list marker: "- Fix carousel sizing."',
+  ]);
+});
+
+test("requires follow-up lines to be bullets", () => {
+  assert.deepEqual(
+    checkChangeset(wrap("Fix carousel sizing.\nPreserve explicit dimensions.")),
+    [
+      'detail line must start with "- ": "Preserve explicit dimensions."',
+    ]
+  );
+});


### PR DESCRIPTION
## Summary

- align changeset summaries with `@changesets/changelog-github`, which adds the top-level release bullet itself
- migrate pending changesets to a plain first summary line with optional nested detail bullets
- clean duplicated bullets from existing v5 beta changelog entries and add regression tests for the style checker

## Why

The previous bullet-only convention rendered first lines as `- - ...` in both the generated release PR and `CHANGELOG.md`.

## Verification

- reproduced the duplicated bullet with the installed `@changesets/changelog-github@0.5.0`
- `yarn format`
- `yarn lint`
- `yarn types`
- `yarn test --runInBand` (357 tests)
- `node --test scripts/check-changeset-style.test.mjs` (4 tests)
- `yarn changeset:check` (20 changesets)
- isolated `changeset version` dry run generated `5.0.0-beta.8` with correct #931/#933 release notes and no duplicated bullets

This does not change `.changeset/pre.json`, `package.json`, the package version, or runtime code.
