### PR TITLE
docs: improve v5 beta documentation experience

### DIFF
--- a/example/app/app/demos/utils/pagination/demo.tsx
+++ b/example/app/app/demos/utils/pagination/demo.tsx
@@ -56,6 +56,7 @@ function Index() {
         activeDotStyle={{ backgroundColor: "#f1f1f1" }}
         containerStyle={{ gap: 5, marginBottom: 10 }}
         onPress={onPressPagination}
+        carouselName="Color carousel"
       />
 
       <Pagination.Basic<{ color: string }>
@@ -76,6 +77,10 @@ function Index() {
         }}
         horizontal
         onPress={onPressPagination}
+        paginationItemAccessibility={(index, length) => ({
+          accessibilityLabel: `Color ${index + 1} of ${length}`,
+          accessibilityHint: `Go to color ${index + 1}`,
+        })}
       />
 
       <Pagination.Basic<{ color: string }>

--- a/example/app/app/demos/utils/pagination/index.tsx
+++ b/example/app/app/demos/utils/pagination/index.tsx
@@ -55,6 +55,7 @@ function Index() {
           activeDotStyle={{ backgroundColor: "#f1f1f1" }}
           containerStyle={{ gap: 5, marginBottom: 10 }}
           onPress={onPressPagination}
+          carouselName="Color carousel"
         />
 
         <Pagination.Basic<{ color: string }>
@@ -75,6 +76,10 @@ function Index() {
           }}
           horizontal
           onPress={onPressPagination}
+          paginationItemAccessibility={(index, length) => ({
+            accessibilityLabel: `Color ${index + 1} of ${length}`,
+            accessibilityHint: `Go to color ${index + 1}`,
+          })}
         />
 
         <Pagination.Basic<{ color: string }>

--- a/example/website/pages/404.mdx
+++ b/example/website/pages/404.mdx
@@ -1,0 +1,12 @@
+---
+title: Page not found
+description: The requested React Native Reanimated Carousel documentation page could not be found.
+---
+
+# Page not found
+
+The documentation page you requested does not exist or may have moved.
+
+- [Return to Getting Started](/)
+- [Browse the examples](/Examples/summary)
+- [Search existing GitHub issues](https://github.com/dohooo/react-native-reanimated-carousel/issues)

--- a/example/website/pages/Examples/utils/pagination.mdx
+++ b/example/website/pages/Examples/utils/pagination.mdx
@@ -117,6 +117,7 @@ function Index() {
 				activeDotStyle={{ backgroundColor: "#f1f1f1" }}
 				containerStyle={{ gap: 5, marginBottom: 10 }}
 				onPress={onPressPagination}
+				carouselName="Color carousel"
 			/>
 
 			<Pagination.Basic<{ color: string }>
@@ -137,6 +138,10 @@ function Index() {
 				}}
 				horizontal
 				onPress={onPressPagination}
+				paginationItemAccessibility={(index, length) => ({
+					accessibilityLabel: `Color ${index + 1} of ${length}`,
+					accessibilityHint: `Go to color ${index + 1}`,
+				})}
 			/>
 
 			<Pagination.Basic<{ color: string }>

--- a/example/website/pages/_app.js
+++ b/example/website/pages/_app.js
@@ -1,7 +1,6 @@
 import "../styles.css";
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
-import Script from "next/script";
 
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 
@@ -23,17 +22,5 @@ export default function MyApp({
 }) {
   const page = <Component {...pageProps} />;
 
-  return (
-    <>
-      {/* Google AdSense Script */}
-      <Script
-        async
-        src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2209220476314227"
-        crossOrigin="anonymous"
-        strategy="afterInteractive"
-      />
-      
-      {posthogKey ? <PostHogProvider client={posthog}>{page}</PostHogProvider> : page}
-    </>
-  );
+  return posthogKey ? <PostHogProvider client={posthog}>{page}</PostHogProvider> : page;
 }

--- a/example/website/pages/_document.js
+++ b/example/website/pages/_document.js
@@ -1,0 +1,20 @@
+import { Head, Html, Main, NextScript } from "next/document";
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        <script
+          async
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2209220476314227"
+          data-overlays="collapsed-bottom"
+          crossOrigin="anonymous"
+        />
+      </Head>
+      <body className="google-anno-skip">
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/example/website/pages/usage.mdx
+++ b/example/website/pages/usage.mdx
@@ -32,6 +32,7 @@ Here is a simple usage of the **React Native Reanimated Carousel**. For more scr
 ```tsx
 import * as React from "react";
 import { Dimensions, Text, View } from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { useSharedValue } from "react-native-reanimated";
 import Carousel, {
   ICarouselInstance,
@@ -57,7 +58,7 @@ function App() {
   };
 
   return (
-    <View style={{ flex: 1 }}>
+    <GestureHandlerRootView style={{ flex: 1 }}>
       <Carousel
         ref={ref}
         style={{ width, height: width / 2 }}
@@ -82,12 +83,30 @@ function App() {
         dotStyle={{ backgroundColor: "rgba(0,0,0,0.2)", borderRadius: 50 }}
         containerStyle={{ gap: 5, marginTop: 10 }}
         onPress={onPressPagination}
+        carouselName="Main carousel"
       />
-    </View>
+    </GestureHandlerRootView>
   );
 }
 
 export default App;
+```
+
+### Accessible Pagination
+
+`Pagination.Basic` and `Pagination.Custom` announce each item as a button by default. Set `carouselName` to add context to the default label, or use `paginationItemAccessibility` when you need custom or localized announcements:
+
+```tsx
+<Pagination.Basic
+  progress={progress}
+  data={data}
+  onPress={onPressPagination}
+  carouselName="Featured products"
+  paginationItemAccessibility={(index, length) => ({
+    accessibilityLabel: `Product ${index + 1} of ${length}`,
+    accessibilityHint: `Go to product ${index + 1}`,
+  })}
+/>
 ```
 
 ## Sizing Your Carousel


### PR DESCRIPTION
## Summary

- make the Usage example copy-paste ready by wrapping it in `GestureHandlerRootView`
- document and demonstrate accessible pagination labels and hints
- add a useful documentation 404 page with recovery links
- move AdSense into the document head, prevent ad-intent annotations from rewriting docs content, and use a regular bottom anchor instead of the large dynamic overlay

## Why

The v5 public-beta developer experience audit found that the published package and README quick start work in a clean Expo SDK 57 app, but the documentation path still had avoidable friction: the Usage example omitted the required gesture root, the new pagination accessibility API was hard to discover, the default 404 had no way back into the docs, and automatic ads obscured content and polluted the accessibility/search tree.

## Validation

- installed `react-native-reanimated-carousel@beta` from npm in a clean Expo SDK 57 app
- passed `npx tsc --noEmit`, `npx expo install --check`, and Expo Doctor (20/20)
- generated an iOS bundle from the README quick-start app
- passed `yarn types`, `yarn format`, `yarn lint`, and `yarn changeset:check`
- passed `yarn types` in `example/app`
- generated the example pages and completed a production Next.js build
- verified the home, Usage, and custom 404 pages in a local browser build

## Release impact

Documentation and examples only. No package changeset is required and npm behavior is unchanged.
