### PR TITLE
ci: bootstrap v5 stabilization branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - develop
+      - dohooo/v5-release-main
   pull_request:
     branches:
       - main
       - develop
+      - dohooo/v5-release-main
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - dohooo/v5-release-main
     paths:
       - "src/**"
       - "e2e/fixtures/packed-expo/**"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, dohooo/v5-release-main]
 
 jobs:
   changes:


### PR DESCRIPTION
## Summary

- run CI for pull requests and pushes targeting the v5 stabilization branch
- run E2E after changes land on the v5 stabilization branch
- run the packed Expo compatibility matrix for pull requests targeting the v5 stabilization branch
- keep npm publishing and documentation deployment restricted to `main`

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yaml .github/workflows/compatibility.yml`
- parsed all affected workflows and asserted the expected branch filters
- confirmed `.github/workflows/release.yml` remains `main`-only
- repository pre-commit Biome checks

No changeset is needed because this only changes CI triggers.
