### PR TITLE
fix: avoid reading pagination progress during re-renders

### DIFF
--- a/.changeset/pagination-lazy-selected-state.md
+++ b/.changeset/pagination-lazy-selected-state.md
@@ -1,0 +1,5 @@
+---
+"react-native-reanimated-carousel": patch
+---
+
+Fix Pagination re-renders triggering the Reanimated strict mode warning about reading `value` during component render.

--- a/src/components/Pagination/PaginationItem.tsx
+++ b/src/components/Pagination/PaginationItem.tsx
@@ -71,8 +71,12 @@ export function PaginationItem(props: {
   const activeBackgroundColor = activeDotStyle?.backgroundColor ?? DEFAULT_ACTIVE_DOT_COLOR;
   const activeOpacity = activeDotStyle?.opacity ?? baseOpacity;
 
+  // Lazy initializer: React only invokes it on the first render, which is
+  // exempt from Reanimated's "reading `value` during render" strict check.
+  // A plain expression would re-read `progress.value` on every re-render
+  // and trigger the warning (issue #940).
   const [selected, setSelected] = React.useState(
-    count === 1 || getPaginationSelectedIndex(progress.value, count) === index
+    () => count === 1 || getPaginationSelectedIndex(progress.value, count) === index
   );
 
   useAnimatedReaction(

--- a/src/components/Pagination/issue-940-strict-mode-warning.test.tsx
+++ b/src/components/Pagination/issue-940-strict-mode-warning.test.tsx
@@ -1,0 +1,65 @@
+import { useSharedValue } from "react-native-reanimated";
+
+import { render } from "@testing-library/react-native";
+
+import { Pagination } from ".";
+
+const STRICT_RENDER_READ_WARNING = "Reading from `value` during component render";
+
+type LoggerData = { level: number; message: string };
+type LoggerConfig = { logFunction: (data: LoggerData) => void };
+
+const loggerConfig = (global as unknown as { __reanimatedLoggerConfig?: LoggerConfig })
+  .__reanimatedLoggerConfig;
+
+if (!loggerConfig) {
+  throw new Error(
+    "Expected reanimated logger config to be installed by setUpTests(); cannot capture strict mode warnings."
+  );
+}
+
+const capturedMessages: string[] = [];
+let originalLogFunction: LoggerConfig["logFunction"];
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  capturedMessages.length = 0;
+  originalLogFunction = loggerConfig.logFunction;
+  loggerConfig.logFunction = (data) => {
+    capturedMessages.push(data.message);
+  };
+});
+
+afterEach(() => {
+  loggerConfig.logFunction = originalLogFunction;
+  jest.useRealTimers();
+});
+
+function strictRenderReadWarnings() {
+  return capturedMessages.filter((message) => message.includes(STRICT_RENDER_READ_WARNING));
+}
+
+function PaginationHarness(_props: { tick: number }) {
+  const progress = useSharedValue(0);
+  return <Pagination count={3} progress={progress} />;
+}
+
+describe("issue #940 Pagination strict mode warning", () => {
+  it("control: first render alone does not warn (Reanimated exempts the first render)", () => {
+    render(<PaginationHarness tick={0} />);
+
+    expect(strictRenderReadWarnings()).toEqual([]);
+  });
+
+  it("does not read progress.value during component render (initial + re-render)", () => {
+    const screen = render(<PaginationHarness tick={0} />);
+
+    // A parent-driven re-render is enough: the `useState` initializer
+    // expression is re-evaluated on every render (React only ignores the
+    // result), and reads outside the first render are not exempt from
+    // Reanimated's strict mode check.
+    screen.rerender(<PaginationHarness tick={1} />);
+
+    expect(strictRenderReadWarnings()).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #940

### Description

`PaginationItem` initialized its `selected` state with a plain `useState(expression)` call. That expression reads `progress.value`, and React re-evaluates initializer expressions on every render (it only ignores the result). Reads outside the first render are not exempt from Reanimated's strict-mode check, so any parent-driven re-render logged `[Reanimated] Reading from 'value' during component render` once per dot.

Switching to a lazy initializer (`useState(() => ...)`) means the read only happens during the first render, which Reanimated exempts. No behavior change: the initial `selected` value is computed identically.

The new regression test captures the Reanimated logger output: a first render alone must stay silent (control, passes before and after) and a subsequent re-render must stay silent too (failed with 3 warnings — one per dot — before the fix).

### Review

- [x] I self-reviewed this PR

### Testing

- [x] I added or updated automated tests where applicable
- [x] I manually tested the affected platform or documentation
- [x] I added a changeset for a user-facing package change, or this change is docs-only/internal

Commands run:

- `yarn test src/components/Pagination/ --runInBand`
- `yarn test --runInBand`
- `yarn types --pretty false`
- `yarn lint`
- `yarn changeset:check`