### PR TITLE
fix: allow react-native-gesture-handler 3.x as a peer dependency

### DIFF
--- a/.changeset/allow-rngh-3-peer.md
+++ b/.changeset/allow-rngh-3-peer.md
@@ -1,0 +1,5 @@
+---
+"react-native-reanimated-carousel": patch
+---
+
+Allow `react-native-gesture-handler` 3.x as a peer dependency, matching the version shipped with Expo SDK 57 templates.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ export default function App() {
 
 | Carousel | Expo SDK | React Native | Reanimated | Gesture Handler | Worklets |
 |---|---|---|---|---|---|
-| **v5** | **54–57 validated** | **0.80+** | **4.1.0+** | **>=2.9.0 <3.0.0** | **0.5.0+** |
+| **v5** | **54–57 validated** | **0.80+** | **4.1.0+** | **>=2.9.0 <4.0.0** | **0.5.0+** |
 | v4.x (EOL) | 50–53 | 0.70.3+ | 3.0.0+ | 2.9.0+ | — |
 | v3.x (EOL) | 47–49 | 0.66.0+ | 2.0.0+ | 2.0.0+ | — |
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 	"peerDependencies": {
 		"react": ">=18.0.0",
 		"react-native": ">=0.80.0",
-		"react-native-gesture-handler": ">=2.9.0 <3.0.0",
+		"react-native-gesture-handler": ">=2.9.0 <4.0.0",
 		"react-native-reanimated": ">=4.1.0",
 		"react-native-worklets": ">=0.5.0"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -11467,7 +11467,7 @@ __metadata:
   peerDependencies:
     react: ">=18.0.0"
     react-native: ">=0.80.0"
-    react-native-gesture-handler: ">=2.9.0 <3.0.0"
+    react-native-gesture-handler: ">=2.9.0 <4.0.0"
     react-native-reanimated: ">=4.1.0"
     react-native-worklets: ">=0.5.0"
   bin:


### PR DESCRIPTION
Relates to #943, #944, #945 (unblocks their `Expo SDK 57` compatibility check)

### Description

The `Expo SDK 57` compatibility job started failing on every PR: the SDK 57 template now ships `react-native-gesture-handler@~3.1.0`, while this package declares `peerDependencies: ">=2.9.0 <3.0.0"`, so `npm install` of the packed tarball fails with `ERESOLVE`. `main` last ran CI on Jul 25, before the template moved to RNGH 3.1 — this is ecosystem drift, not a regression from any open PR.

This widens the peer range to `">=2.9.0 <4.0.0"`. Compatibility audit against the published `react-native-gesture-handler@3.1.0` types: every symbol this library imports (`Gesture`, `GestureDetector`, `GestureHandlerRootView`, `GestureType`, `MouseButton`, `PanGesture`, `PanGestureHandlerProps`, `PanGestureHandlerEventPayload`, `PanGestureChangeEventPayload`, `GestureStateChangeEvent`, `GestureUpdateEvent`, `State`) is still exported in 3.1.0, and `BaseGesture.config` (incl. the web-only `touchAction` option) is unchanged. The library is JS-only, so no native compatibility surface is involved.

### Review

- [x] I self-reviewed this PR

### Testing

- [x] I added or updated automated tests where applicable (covered by the existing `Expo SDK 57` job, which installs the packed tarball against RNGH 3.1 and type-checks/builds a clean consumer)
- [x] I manually tested the affected platform or documentation
- [x] I added a changeset for a user-facing package change, or this change is docs-only/internal

Commands run:

- `yarn install`
- `yarn lint`
- `yarn changeset:check`
- `bash scripts/test-packed-expo-consumer.sh 57` (local run against the widened range)