### PR TITLE
type-only import the `SharedValue`

### DIFF
--- a/.changeset/verbatim-module-syntax-imports.md
+++ b/.changeset/verbatim-module-syntax-imports.md
@@ -1,0 +1,5 @@
+---
+"react-native-reanimated-carousel": patch
+---
+
+Fix source type-checking when `verbatimModuleSyntax` is enabled.

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { useSharedValue, type SharedValue } from "react-native-reanimated";
+import { type SharedValue, useSharedValue } from "react-native-reanimated";
 import type { CarouselCommonVariables } from "../hooks/useCommonVariables";
 import type { InitializedCarouselProps } from "../hooks/useInitProps";
 

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { SharedValue, useSharedValue } from "react-native-reanimated";
+import { useSharedValue, type SharedValue } from "react-native-reanimated";
 import type { CarouselCommonVariables } from "../hooks/useCommonVariables";
 import type { InitializedCarouselProps } from "../hooks/useInitProps";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "esnext",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "verbatimModuleSyntax": true
   },
   "exclude": ["example", "e2e/fixtures", "node_modules", "**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
<!-- Is this PR related to an open issue? -->
<!-- GitHub: Fixes #0, Relates to #1, etc. -->

### Description

Import `SharedValue` using an explicit type-only import. This is a fix in certain host TypeScript projects that have `verbatimModuleSyntax` enabled.

This is just a quick fix. However for the future, I recommend that this project also enable the `verbatimModuleSyntax` in the `tsconfig.json`.
Somehow we can't disable type-check entirely for node_modules https://github.com/microsoft/TypeScript/issues/40426

<!-- Summary of changes and why if no corresponding issue -->

### Review

- [x] I self-reviewed this PR

<!-- Call out any changes that you'd like people to review or feedback on -->

### Testing

- [ ] I added or updated automated tests where applicable
- [ ] I manually tested the affected platform or documentation
- [ ] I added a changeset for a user-facing package change, or this change is docs-only/internal

<!-- List the exact commands, devices, or pages used for verification -->
