### PR TITLE
ci: retry Android Maestro driver disconnects mid-flow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -32,6 +32,7 @@ jobs:
               - "babel.config.js"
               - "tsconfig.json"
               - ".github/workflows/e2e.yaml"
+              - "scripts/e2e-*"
 
       - name: Show E2E decision
         run: echo "run_e2e=${{ steps.filter.outputs.e2e }}"

--- a/scripts/e2e-maestro-suite.sh
+++ b/scripts/e2e-maestro-suite.sh
@@ -110,11 +110,18 @@ for flow in "${FLOWS[@]}"; do
     fi
 
     if [ "$FLOW_RETRY_DRIVER_STARTUP_TIMEOUTS_ONLY" = "1" ]; then
-      if [ "$flow_status" -ne 124 ] || grep -q "Running on " "$flow_log_file"; then
+      # A dropped Maestro<->device connection surfaces as a gRPC UNAVAILABLE
+      # or a closed adb-server socket mid-flow (often followed by the outer
+      # timeout killing the hung command). That is infrastructure, not a test
+      # verdict, so it stays retryable even after the Flow has started.
+      if grep -Eq 'StatusRuntimeException: UNAVAILABLE|Command failed \(tcp:[0-9]+\): closed' "$flow_log_file"; then
+        echo "Retrying Android Maestro driver disconnect."
+      elif [ "$flow_status" -ne 124 ] || grep -q "Running on " "$flow_log_file"; then
         echo "Not retrying because the Maestro Flow started or did not time out."
         break
+      else
+        echo "Retrying Maestro driver startup timeout before the Flow began."
       fi
-      echo "Retrying Maestro driver startup timeout before the Flow began."
     elif [ "$FLOW_RETRY_IOS_TRANSIENT_DRIVER_FAILURES_ONLY" = "1" ]; then
       if [ "$flow_status" -eq 124 ] && grep -q "kAXErrorInvalidUIElement" "$flow_log_file"; then
         echo "Retrying iOS view-hierarchy driver timeout."

--- a/scripts/e2e-maestro-suite.test.mjs
+++ b/scripts/e2e-maestro-suite.test.mjs
@@ -11,7 +11,13 @@ const repoRoot = path.resolve(
   ".."
 );
 
-async function runFixture({ exitCode = 1, failure, legacyFilter = false }) {
+async function runFixture({
+  exitCode = 1,
+  failure,
+  legacyFilter = false,
+  startupTimeoutFilter = false,
+  hang = false,
+}) {
   const fixtureRoot = await mkdtemp(path.join(tmpdir(), "maestro-retry-"));
 
   try {
@@ -39,6 +45,9 @@ echo "$attempt" > "$FAKE_MAESTRO_STATE"
 
 if [ "$attempt" -eq 1 ] || [ "$FAKE_MAESTRO_RECOVERS" != "1" ]; then
   echo "$FAKE_MAESTRO_FAILURE"
+  if [ "\${FAKE_MAESTRO_HANG:-0}" = "1" ]; then
+    sleep 30
+  fi
   exit "$FAKE_MAESTRO_EXIT_CODE"
 fi
 
@@ -57,6 +66,7 @@ echo "Flow completed"
           E2E_APP_ID: "com.example",
           FAKE_MAESTRO_EXIT_CODE: String(exitCode),
           FAKE_MAESTRO_FAILURE: failure,
+          FAKE_MAESTRO_HANG: hang ? "1" : "0",
           FAKE_MAESTRO_RECOVERS: "1",
           FAKE_MAESTRO_STATE: statePath,
           GITHUB_WORKSPACE: repoRoot,
@@ -65,10 +75,15 @@ echo "Flow completed"
           MAESTRO_FLOW_LOG_DIR: logDir,
           MAESTRO_FLOW_MAX_ATTEMPTS: "2",
           MAESTRO_FLOW_TIMEOUT_SECONDS: "5",
+          MAESTRO_RETRY_DRIVER_STARTUP_TIMEOUTS_ONLY: startupTimeoutFilter
+            ? "1"
+            : "0",
           MAESTRO_RETRY_IOS_VIEW_HIERARCHY_TIMEOUTS_ONLY: legacyFilter
             ? "1"
             : "0",
-          MAESTRO_RETRY_IOS_TRANSIENT_DRIVER_FAILURES_ONLY: "1",
+          MAESTRO_RETRY_IOS_TRANSIENT_DRIVER_FAILURES_ONLY: startupTimeoutFilter
+            ? "0"
+            : "1",
           MAESTRO_REUSE_DRIVER_BETWEEN_FLOWS: "0",
         },
       }
@@ -104,6 +119,36 @@ test("preserves retries for an iOS view-hierarchy timeout", async () => {
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
   assert.equal(attempts, 2);
   assert.match(result.stdout, /Retrying iOS view-hierarchy driver timeout/);
+});
+
+test("retries an Android mid-flow driver disconnect under the startup-timeout filter", async () => {
+  const { attempts, result } = await runFixture({
+    exitCode: 1,
+    failure:
+      "Running on emulator-5554\n  Tap on id: btn-next...io.grpc.StatusRuntimeException: UNAVAILABLE",
+    startupTimeoutFilter: true,
+    hang: true,
+  });
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.equal(attempts, 2);
+  assert.match(result.stdout, /Retrying Android Maestro driver disconnect/);
+});
+
+test("still does not retry a started flow that times out without a disconnect signature", async () => {
+  const { attempts, result } = await runFixture({
+    exitCode: 1,
+    failure: "Running on emulator-5554\nAssertion is false: something",
+    startupTimeoutFilter: true,
+    hang: true,
+  });
+
+  assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`);
+  assert.equal(attempts, 1);
+  assert.match(
+    result.stdout,
+    /Not retrying because the Maestro Flow started or did not time out/
+  );
 });
 
 test("does not retry a non-driver Maestro failure", async () => {


### PR DESCRIPTION
### Description

`e2e-android` keeps failing across unrelated branches (including the release PR #949 and `main` itself) with the same infrastructure signature: the flow hangs mid-run until the outer 600s timeout kills it, and the Maestro log carries `io.grpc.StatusRuntimeException: UNAVAILABLE` (or a closed adb-server socket, `Command failed (tcp:NNN): closed`) — the emulator/driver connection died, which is not a test verdict.

The Android retry filter (`MAESTRO_RETRY_DRIVER_STARTUP_TIMEOUTS_ONLY`) deliberately refuses to retry once a flow has started, so these runs fail on the first disconnect even though the existing per-retry recovery (adb reverse / force-stop) would likely rescue them.

This adds one narrow exception to that filter: a mid-flow attempt whose log contains a driver-disconnect signature stays retryable. A started flow that times out **without** such a signature still fails fast (covered by a new guard test), so genuine hangs are not masked.

Verified with the script's own test harness: a new fixture simulates a hung first attempt carrying the gRPC signature (red before this change, green after), plus a guard fixture asserting no-signature timeouts keep the old behavior. `node --test scripts/e2e-maestro-suite.test.mjs`: 7/7 twice.

### Review

- [x] I self-reviewed this PR

### Testing

- [x] I added or updated automated tests where applicable
- [x] I manually tested the affected platform or documentation
- [x] I added a changeset for a user-facing package change, or this change is docs-only/internal

Commands run:

- `node --test scripts/e2e-maestro-suite.test.mjs` (twice)
- `bash -n scripts/e2e-maestro-suite.sh`
- `yarn lint`